### PR TITLE
Add target .NET Framework 4.5

### DIFF
--- a/src/Superpower/project.json
+++ b/src/Superpower/project.json
@@ -31,12 +31,12 @@
     }
   },
 
-  "dependencies": {
-    "NETStandard.Library": "1.6.0"
-  },
-
   "frameworks": {
+    "net4.5": {},
     "netstandard1.0": {
+      "dependencies": {
+        "NETStandard.Library": "1.6.0"
+      },
       "imports": [
         "dnxcore50",
         "portable-net45+win8"


### PR DESCRIPTION
Hi,

I've found, that [Superpower](https://www.nuget.org/packages/Superpower/), being one of dependencies of [Serilog.Filters.Expressions](https://github.com/serilog/serilog-filters-expressions), builds only for .NETStandard 1.0. So, I suggest to build it for .NET 4.5 too.