### PR TITLE
Better error message about Span.EqualTo(char)

### DIFF
--- a/src/Superpower/Parsers/Span.cs
+++ b/src/Superpower/Parsers/Span.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright 2016 Datalust, Superpower Contributors, Sprache Contributors
-//  
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at  
+// You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0  
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -124,9 +124,7 @@ namespace Superpower.Parsers
             return input =>
             {
                 var result = input.ConsumeChar();
-                if (!result.HasValue)
-                    return Result.CastEmpty<char, TextSpan>(result);
-                if (result.Value == ch)
+                if (result.HasValue && result.Value == ch)
                     return Result.Value(input.Until(result.Remainder), input, result.Remainder);
                 return Result.Empty<TextSpan>(input, expectations);
             };
@@ -144,9 +142,7 @@ namespace Superpower.Parsers
             return input =>
             {
                 var result = input.ConsumeChar();
-                if (!result.HasValue)
-                    return Result.CastEmpty<char, TextSpan>(result);
-                if (char.ToUpperInvariant(result.Value) == chToUpper)
+                if (result.HasValue && char.ToUpperInvariant(result.Value) == chToUpper)
                    return Result.Value(input.Until(result.Remainder), input, result.Remainder);
                 return Result.Empty<TextSpan>(input, expectations);
             };


### PR DESCRIPTION
If we try as example this code `Span.EqualTo('a')("")` (it's not an exact code, it's only a simplified model) then we expect something as this `expected 'a' but got end of input` (as now), but in past we have `unexpected end of input`.

Be sure, your tests works as expected. I'am not check this, as long as I don't use the xUnit.


P.S. My English is not fluent, so you must enable your imagination and then you'll be able parse this message :)