### PR TITLE
Added Between() combinator

### DIFF
--- a/src/Superpower/Combinators.cs
+++ b/src/Superpower/Combinators.cs
@@ -177,6 +177,39 @@ namespace Superpower
         }
 
         /// <summary>
+        /// Construct a parser that matches <paramref name="left"/>, discards the resulting value,
+        /// then matches <paramref name="parser"/>, keeps the value, then matches <paramref name="right"/>
+        /// and returns the value matched by <paramref name="parser"/>.
+        /// </summary>
+        /// <typeparam name="TKind">The kind of the tokens being parsed.</typeparam>
+        /// <typeparam name="T">The type of value being parsed.</typeparam>
+        /// <typeparam name="U">The type of the resulting value.</typeparam>
+        /// <param name="parser">The parser.</param>
+        /// <param name="left">First parser to match, value is ignored.</param>
+        /// <param name="right">Last parser to match, value is ignored.</param>
+        /// <returns>The resulting parser.</returns>
+        public static TokenListParser<TKind, T> Between<TKind, T, U>(this TokenListParser<TKind, T> parser, TokenListParser<TKind, U> left, TokenListParser<TKind, U> right)
+        {
+            return left.IgnoreThen(parser.Then(right.Value));
+        }
+
+        /// <summary>
+        /// Construct a parser that matches <paramref name="left"/>, discards the resulting value,
+        /// then matches <paramref name="parser"/>, keeps the value, then matches <paramref name="right"/>
+        /// and returns the value matched by <paramref name="parser"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of value being parsed.</typeparam>
+        /// <typeparam name="U">The type of the resulting value.</typeparam>
+        /// <param name="parser">The parser.</param>
+        /// <param name="left">First parser to match, value is ignored.</param>
+        /// <param name="right">Last parser to match, value is ignored.</param>
+        /// <returns>The resulting parser.</returns>
+        public static TextParser<T> Between<T, U>(this TextParser<T> parser, TextParser<U> left, TextParser<U> right)
+        {
+            return left.IgnoreThen(parser.Then(right.Value));
+        }
+
+        /// <summary>
         /// Construct a parser that matches <paramref name="first"/>, discards the resulting value, then returns the result of <paramref name="second"/>.
         /// </summary>
         /// <typeparam name="TKind">The kind of the tokens being parsed.</typeparam>

--- a/test/Superpower.Tests/Combinators/BetweenCombinatorTests.cs
+++ b/test/Superpower.Tests/Combinators/BetweenCombinatorTests.cs
@@ -25,27 +25,32 @@ namespace Superpower.Tests.Combinators
         }
 
         [Fact]
-        public void BetweenSucceedsIfAllParsersSucceed() {
+        public void BetweenSucceedsIfAllParsersSucceed()
+        {
             AssertParser.SucceedsWith( Character.EqualTo( 'a' ).Between( Character.EqualTo( '(' ), Character.EqualTo( ')' ) ), "(a)", 'a' );
         }
 
         [Fact]
-        public void TokenBetweenFailsIfLeftParserFails() {
+        public void TokenBetweenFailsIfLeftParserFails()
+        {
             AssertParser.Fails( Token.EqualTo( 'a' ).Between( Token.EqualTo( '(' ), Token.EqualTo( ')' ) ), "{a)" );
         }
 
         [Fact]
-        public void TokenBetweenFailsIfRightParserFails() {
+        public void TokenBetweenFailsIfRightParserFails()
+        {
             AssertParser.Fails( Token.EqualTo( 'a' ).Between( Token.EqualTo( '(' ), Token.EqualTo( ')' ) ), "(a}" );
         }
 
         [Fact]
-        public void TokenBetweenFailsIfMiddleParserFails() {
+        public void TokenBetweenFailsIfMiddleParserFails()
+        {
             AssertParser.Fails( Token.EqualTo( 'a' ).Between( Token.EqualTo( '(' ), Token.EqualTo( ')' ) ), "(b)" );
         }
 
         [Fact]
-        public void TokenBetweenSucceedsIfAllParsersSucceed() {
+        public void TokenBetweenSucceedsIfAllParsersSucceed()
+        {
             AssertParser.SucceedsWith( Token.EqualTo( 'a' ).Between( Token.EqualTo( '(' ), Token.EqualTo( ')' ) ), "(a)", 'a' );
         }
     }

--- a/test/Superpower.Tests/Combinators/BetweenCombinatorTests.cs
+++ b/test/Superpower.Tests/Combinators/BetweenCombinatorTests.cs
@@ -1,0 +1,52 @@
+﻿using Superpower.Parsers;
+using Superpower.Tests.Support;
+using Xunit;
+
+namespace Superpower.Tests.Combinators
+{
+    public class BetweenCombinatorTests
+    {
+        [Fact]
+        public void BetweenFailsIfLeftParserFails()
+        {
+            AssertParser.Fails(Character.EqualTo('a').Between(Character.EqualTo('('), Character.EqualTo(')')), "{a)");
+        }
+
+        [Fact]
+        public void BetweenFailsIfRightParserFails()
+        {
+            AssertParser.Fails(Character.EqualTo('a').Between(Character.EqualTo('('), Character.EqualTo(')')), "(a}");
+        }
+
+        [Fact]
+        public void BetweenFailsIfMiddleParserFails()
+        {
+            AssertParser.Fails(Character.EqualTo('a').Between(Character.EqualTo('('), Character.EqualTo(')')), "(b)");
+        }
+
+        [Fact]
+        public void BetweenSucceedsIfAllParsersSucceed() {
+            AssertParser.SucceedsWith( Character.EqualTo( 'a' ).Between( Character.EqualTo( '(' ), Character.EqualTo( ')' ) ), "(a)", 'a' );
+        }
+
+        [Fact]
+        public void TokenBetweenFailsIfLeftParserFails() {
+            AssertParser.Fails( Token.EqualTo( 'a' ).Between( Token.EqualTo( '(' ), Token.EqualTo( ')' ) ), "{a)" );
+        }
+
+        [Fact]
+        public void TokenBetweenFailsIfRightParserFails() {
+            AssertParser.Fails( Token.EqualTo( 'a' ).Between( Token.EqualTo( '(' ), Token.EqualTo( ')' ) ), "(a}" );
+        }
+
+        [Fact]
+        public void TokenBetweenFailsIfMiddleParserFails() {
+            AssertParser.Fails( Token.EqualTo( 'a' ).Between( Token.EqualTo( '(' ), Token.EqualTo( ')' ) ), "(b)" );
+        }
+
+        [Fact]
+        public void TokenBetweenSucceedsIfAllParsersSucceed() {
+            AssertParser.SucceedsWith( Token.EqualTo( 'a' ).Between( Token.EqualTo( '(' ), Token.EqualTo( ')' ) ), "(a)", 'a' );
+        }
+    }
+}


### PR DESCRIPTION
Added `Between()` combinator allowing to match values, and return the result, between matching a left and a right combinator.

A simple example could e.g. be to match an expression between two parenthesis, such as 

`Expr.Between( Token.EqualTo( Token.LPar ), Token.EqualTo( Token. RPar ) )`

If successful, the result returned is the  result matched by the `Expr` parser.