### PR TITLE
Operator groups

### DIFF
--- a/src/Superpower/OperatorGroups/IOperatorGroup.cs
+++ b/src/Superpower/OperatorGroups/IOperatorGroup.cs
@@ -1,0 +1,28 @@
+namespace Superpower.OperatorGroups
+{
+    /// <summary>
+    /// Definition of a group of operators with a given operator precedence. Operators can either be
+    /// prefix or infix operators, used to combine expressions where operator precedence is important.
+    /// </summary>
+    /// <typeparam name="TKind">The kind of the tokens being parsed.</typeparam>
+    /// <typeparam name="T">The type of value being parsed.</typeparam>
+    public interface IOperatorGroup<TKind, T>
+    {
+        /// <summary>
+        /// Precedence of operators in group. The higher the precedence, the "harder" the
+        /// operator binds.
+        /// </summary>
+        int Precedence { get; }
+
+        /// <summary>
+        /// <para>
+        /// Method for building a new <see cref="TokenListParser{TToken,TResult}"/> parser
+        /// representing operators in group.
+        /// </para>
+        /// <para>The resulting parser will match one or more operands combined with the operators in
+        /// the group, or just the <paramref name="operandParser"/> itself.
+        /// </para>
+        /// </summary>
+        TokenListParser<TKind, T> BuildParser(TokenListParser<TKind, T> operandParser);
+    }
+}

--- a/src/Superpower/OperatorGroups/InfixOprAssociativity.cs
+++ b/src/Superpower/OperatorGroups/InfixOprAssociativity.cs
@@ -1,0 +1,18 @@
+﻿namespace Superpower.OperatorGroups
+{
+    /// <summary>
+    /// Defines is the associativity (left or right) or a binary infix operator
+    /// </summary>
+    public enum InfixOprAssociativity
+    {
+        /// <summary>
+        /// Operator is left associative
+        /// </summary>
+        Left,
+
+        /// <summary>
+        /// Operator is right associative
+        /// </summary>
+        Right
+    }
+}

--- a/src/Superpower/OperatorGroups/InfixOprGroup.cs
+++ b/src/Superpower/OperatorGroups/InfixOprGroup.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Linq;
+using Superpower.Parsers;
+
+namespace Superpower.OperatorGroups
+{
+    /// <summary>
+    /// Definition of binary infix operators
+    /// </summary>
+    /// <typeparam name="TKind">Type of tokens parsed</typeparam>
+    /// <typeparam name="T">Type of result output by parser</typeparam>
+    /// <typeparam name="U">Type of binary operators which tokens are transformed into</typeparam>
+    public class InfixOprGroup<TKind, T, U>
+        : IOperatorGroup<TKind, T>
+    {
+        private readonly InfixOprAssociativity _associativity;
+        private readonly TKind[] _tokens;
+        private readonly Func<TKind, U> _tokenToOperator;
+        private readonly Func<U, T, T, T> _resultBuilder;
+
+        /// <summary>
+        /// Create an <see cref="InfixOprGroup{TKind,T,U}"/> representing a group of infix
+        /// operators with same <see cref="Precedence"/>.
+        /// </summary>
+        /// <param name="precedence">Operator precedence of all operators specified</param>
+        /// <param name="associativity">Specification if operators are left or right associative</param>
+        /// <param name="tokenToOperator">Function for transforming token of type <typeparamref name="TKind"/>
+        /// into binary operator of type <typeparamref name="U"/></param>
+        /// <param name="resultBuilder">Function for creating result of type <typeparamref name="T"/>
+        /// given an operator of type <typeparamref name="U"/> and two arguments of type
+        /// <typeparamref name="T"/></param>
+        /// <param name="tokens">Tokens representing operators in this operator group</param>
+        public InfixOprGroup(
+            int precedence,
+            InfixOprAssociativity associativity,
+            Func<TKind, U> tokenToOperator,
+            Func<U, T, T, T> resultBuilder,
+            params TKind[] tokens)
+        {
+            Precedence = precedence;
+            _associativity = associativity;
+            _tokens = tokens;
+            _tokenToOperator = tokenToOperator;
+            _resultBuilder = resultBuilder;
+
+            // Validate that token mapping works
+            foreach ( var token in tokens ) {
+                try {
+                    tokenToOperator(token);
+                }
+                catch {
+                    throw new InvalidDataException($"Token {token} is not mapped correctly");
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public int Precedence { get; }
+
+        /// <inheritdoc />
+        public TokenListParser<TKind, T> BuildParser(TokenListParser<TKind, T> operandParser)
+        {
+            var oprParsers = _tokens
+                .Select(token => Token.EqualTo(token).Value(_tokenToOperator(token)))
+                .Aggregate(Combinators.Or);
+
+            return
+                _associativity == InfixOprAssociativity.Left ?
+                    // Do not use the Parse.Chain operator - it can cause stack overflow
+                    Parse.Chain(oprParsers, operandParser, _resultBuilder) :
+                    Parse.ChainRight(oprParsers, operandParser, _resultBuilder);
+        }
+    }
+}

--- a/src/Superpower/OperatorGroups/OperatorGroupExtensions.cs
+++ b/src/Superpower/OperatorGroups/OperatorGroupExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Superpower.OperatorGroups
+{
+    /// <summary>
+    /// Extension methods used for defining parsers based on collections of
+    /// <see cref="IEnumerable{IOperatorGroup}"/>
+    /// </summary>
+    public static class OperatorGroupExtensions
+    {
+        /// <summary>
+        /// Create <see cref="TokenListParser{TKind,T}"/> representing
+        /// operators defined in <paramref name="operatorGroups"/>
+        /// </summary>
+        /// <typeparam name="TKind">The kind of token being parsed.</typeparam>
+        /// <typeparam name="T">The type being parsed.</typeparam>
+        public static TokenListParser<TKind, T> DefineParser<TKind, T>(
+            this IEnumerable<IOperatorGroup<TKind, T>> operatorGroups,
+            TokenListParser<TKind, T> operandParser)
+        {
+            return operatorGroups
+                .OrderByDescending(g => g.Precedence)
+                .Aggregate(operandParser, (p, g) => g.BuildParser(p));
+        }
+    }
+}

--- a/src/Superpower/OperatorGroups/PrefixOprGroup.cs
+++ b/src/Superpower/OperatorGroups/PrefixOprGroup.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using System.Linq;
+using Superpower.Parsers;
+
+namespace Superpower.OperatorGroups
+{
+    /// <summary>
+    /// Definition of group of unary prefix operators
+    /// </summary>
+    /// <typeparam name="TKind">The kind of the tokens being parsed.</typeparam>
+    /// <typeparam name="T">The type of value being parsed.</typeparam>
+    /// <typeparam name="U">The type of the operator.</typeparam>
+    public class PrefixOprGroup<TKind, T, U> : IOperatorGroup<TKind, T>
+    {
+        private readonly TKind[] _tokens;
+        private readonly Func<TKind, U> _tokenToOperator;
+        private readonly Func<U, T, T> _resultBuilder;
+
+        /// <summary>
+        /// Create <see cref="PrefixOprGroup{TKind,T,U}"/> representing a group of prefix
+        /// operators with same <see cref="Precedence"/>
+        /// </summary>
+        /// <param name="precedence">Operator precedence of all operators specified</param>
+        /// <param name="tokenToOperator">Function for transforming token of type <typeparamref name="TKind"/>
+        /// into unary operator of type <typeparamref name="U"/></param>
+        /// <param name="resultBuilder">Function for creating result of type <typeparamref name="T"/>
+        /// given an operator of type <typeparamref name="U"/> and one arguments of type
+        /// <typeparamref name="T"/></param>
+        /// <param name="tokens">Tokens representing operators in this operator group</param>
+        public PrefixOprGroup(
+            int precedence,
+            Func<TKind, U> tokenToOperator,
+            Func<U, T, T> resultBuilder,
+            params TKind[] tokens)
+        {
+            Precedence = precedence;
+            _tokens = tokens;
+            _tokenToOperator = tokenToOperator;
+            _resultBuilder = resultBuilder;
+
+            // Validate that token mapping works
+            foreach ( var token in tokens ) {
+                try {
+                    tokenToOperator(token);
+                }
+                catch {
+                    throw new InvalidDataException($"Token {token} is not mapped correctly");
+                }
+            }
+
+        }
+
+        /// <inheritdoc />
+        public int Precedence { get; }
+
+        /// <inheritdoc />
+        public TokenListParser<TKind, T> BuildParser(TokenListParser<TKind, T> operandParser)
+        {
+
+            TokenListParser<TKind, U> operatorParser = _tokens
+                .Select(token => Token.EqualTo(token).Value(_tokenToOperator(token)))
+                .Aggregate((p1, p2) => p1.Or(p2));
+
+            return operatorParser
+                .Many()
+                .Then(oprs => operandParser.Select(operand =>
+                    oprs.Aggregate(operand, (o, opr) => _resultBuilder(opr, o))));
+        }
+    }
+}

--- a/test/Superpower.Tests/BoolExpressionScenario/BoolExpressionParser.cs
+++ b/test/Superpower.Tests/BoolExpressionScenario/BoolExpressionParser.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Superpower.OperatorGroups;
+using Superpower.Parsers;
+
+namespace Superpower.Tests.BoolExpressionScenario
+{
+    class BoolExpressionParser
+    {
+        /// <summary>
+        /// Mapping from token representing operator to expression operator
+        /// </summary>
+        private static readonly Dictionary<BoolExpressionToken, ExpressionType> TokenToOprMap =
+            new Dictionary<BoolExpressionToken, ExpressionType> {
+                { BoolExpressionToken.Plus, ExpressionType.AddChecked },
+                { BoolExpressionToken.Minus, ExpressionType.SubtractChecked },
+                { BoolExpressionToken.Times, ExpressionType.Multiply },
+                { BoolExpressionToken.Divide, ExpressionType.Divide },
+                { BoolExpressionToken.Lt, ExpressionType.LessThan },
+                { BoolExpressionToken.Gt, ExpressionType.GreaterThan },
+                { BoolExpressionToken.And, ExpressionType.And },
+                { BoolExpressionToken.Or, ExpressionType.Or },
+                { BoolExpressionToken.Not, ExpressionType.Not }
+            };
+
+        /// <summary>
+        /// Define a simple integer constant
+        /// </summary>
+        static readonly TokenListParser<BoolExpressionToken, Expression> Constant =
+            Token.EqualTo(BoolExpressionToken.Number)
+                .Apply(Numerics.IntegerInt32)
+                .Select(n => (Expression) Expression.Constant(n));
+
+        /// <summary>
+        /// The variable naming convention in the example is, that variables starting with 'b'
+        /// are Boolean variables, all other variables are integer variables (should start with 'i')
+        /// </summary>
+        private static readonly TokenListParser<BoolExpressionToken, Expression> Variable =
+            Token.EqualTo(BoolExpressionToken.Variable)
+                .Select(v => (Expression) Expression.Variable(
+                    v.ToStringValue()[0] == 'b' ? typeof( bool ) : typeof( Int32 ),
+                    v.ToStringValue()));
+
+        static readonly TokenListParser<BoolExpressionToken, Expression> Factor =
+            ( from lparen in Token.EqualTo(BoolExpressionToken.LParen)
+                from expr in Parse.Ref(() => Expr)
+                from rparen in Token.EqualTo(BoolExpressionToken.RParen)
+                select expr )
+            .Or(Constant).Or(Variable);
+
+        private static readonly TokenListParser<BoolExpressionToken, Expression> Expr =
+            new List<IOperatorGroup<BoolExpressionToken, Expression>> {
+                new InfixOprGroup<BoolExpressionToken, Expression, ExpressionType>(
+                    1, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
+                    BoolExpressionToken.Or),
+                new InfixOprGroup<BoolExpressionToken, Expression, ExpressionType>(
+                    2, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
+                    BoolExpressionToken.And),
+                new InfixOprGroup<BoolExpressionToken, Expression, ExpressionType>(
+                    3, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
+                    BoolExpressionToken.Lt, BoolExpressionToken.Gt),
+                new InfixOprGroup<BoolExpressionToken, Expression, ExpressionType>(
+                    4, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
+                    BoolExpressionToken.Plus, BoolExpressionToken.Minus),
+                new InfixOprGroup<BoolExpressionToken, Expression, ExpressionType>(
+                    5, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
+                    BoolExpressionToken.Times, BoolExpressionToken.Divide),
+                new PrefixOprGroup<BoolExpressionToken,Expression,ExpressionType>(
+                    6, t => TokenToOprMap[t], (oprType, expr)=>Expression.MakeUnary(oprType,expr,null),
+                    BoolExpressionToken.Not)
+            }.DefineParser(Factor);
+
+        public static readonly TokenListParser<BoolExpressionToken, Expression<Func<bool>>> Lambda =
+            Expr
+                .AtEnd()
+                .Select(body => Expression.Lambda<Func<bool>>(body));
+    }
+}

--- a/test/Superpower.Tests/BoolExpressionScenario/BoolExpressionScenarioTests.cs
+++ b/test/Superpower.Tests/BoolExpressionScenario/BoolExpressionScenarioTests.cs
@@ -1,0 +1,24 @@
+﻿using Xunit;
+
+namespace Superpower.Tests.BoolExpressionScenario
+{
+    public class BoolExpressionScenarioTests
+    {
+        [Theory]
+        [InlineData("1 + 2 * 2 > 0", "() => ((1 + (2 * 2)) > 0)")]
+        [InlineData("3 * 2 / 1 < 4 / 3 + 1", "() => (((3 * 2) / 1) < ((4 / 3) + 1))")]
+        [InlineData("3 * i1 / i2 > i3", "() => (((3 * i1) / i2) > i3)")]
+        [InlineData("i1 + i2 + i3 + i4 + i5 > 0 ", "() => (((((i1 + i2) + i3) + i4) + i5) > 0)")]
+        [InlineData("b1 & !b2 & b3", "() => ((b1 And Not(b2)) And b3)")]
+        [InlineData( "!b1 | !b2 & !b3", "() => (Not(b1) Or (Not(b2) And Not(b3)))" )]
+        [InlineData( "!(b1 | !b2)", "() => Not((b1 Or Not(b2)))" )]
+        [InlineData( "!!b1", "() => Not(Not(b1))" )]
+        public void EnsureExpectedOperatorPrecedence(string exprString, string expected)
+        {
+            var tokenizer = new BoolExpressionTokenizer();
+            var expression = BoolExpressionParser.Lambda(tokenizer.Tokenize(exprString));
+            Assert.True(expression.HasValue);
+            Assert.Equal(expected, expression.Value.ToString());
+        }
+    }
+}

--- a/test/Superpower.Tests/BoolExpressionScenario/BoolExpressionToken.cs
+++ b/test/Superpower.Tests/BoolExpressionScenario/BoolExpressionToken.cs
@@ -1,0 +1,46 @@
+﻿using Superpower.Display;
+
+namespace Superpower.Tests.BoolExpressionScenario
+{
+    public enum BoolExpressionToken
+    {
+        None,
+
+        Number,
+
+        Variable,
+
+        [Token(Category = "operator", Example = "+")]
+        Plus,
+
+        [Token(Category = "operator", Example = "-")]
+        Minus,
+
+        [Token(Category = "operator", Example = "*")]
+        Times,
+
+        [Token(Category = "operator", Example = "-")]
+        Divide,
+
+        [Token( Category = "operator", Example = "<" )]
+        Lt,
+
+        [Token( Category = "operator", Example = ">" )]
+        Gt,
+
+        [Token( Category = "operator", Example = "&" )]
+        And,
+
+        [Token( Category = "operator", Example = "|" )]
+        Or,
+
+        [Token( Category = "operator", Example = "!" )]
+        Not,
+
+        [Token(Example = "(")]
+        LParen,
+
+        [Token(Example = ")")]
+        RParen
+    }
+}

--- a/test/Superpower.Tests/BoolExpressionScenario/BoolExpressionTokenizer.cs
+++ b/test/Superpower.Tests/BoolExpressionScenario/BoolExpressionTokenizer.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using Superpower.Model;
+using Superpower.Parsers;
+
+namespace Superpower.Tests.BoolExpressionScenario
+{
+    class BoolExpressionTokenizer : Tokenizer<BoolExpressionToken>
+    {
+        readonly Dictionary<char, BoolExpressionToken> _operators = new Dictionary<char, BoolExpressionToken>
+        {
+            ['+'] = BoolExpressionToken.Plus,
+            ['-'] = BoolExpressionToken.Minus,
+            ['*'] = BoolExpressionToken.Times,
+            ['/'] = BoolExpressionToken.Divide,
+            ['('] = BoolExpressionToken.LParen,
+            [')'] = BoolExpressionToken.RParen,
+            ['&'] = BoolExpressionToken.And,
+            ['|'] = BoolExpressionToken.Or,
+            ['>'] = BoolExpressionToken.Gt,
+            ['<'] = BoolExpressionToken.Lt,
+            ['!'] = BoolExpressionToken.Not
+        };
+
+        protected override IEnumerable<Result<BoolExpressionToken>> Tokenize(TextSpan span)
+        {
+            var next = SkipWhiteSpace(span);
+            if (!next.HasValue)
+                yield break;
+
+            do
+            {
+                BoolExpressionToken charToken;
+
+                if (char.IsDigit(next.Value))
+                {
+                    var integer = Numerics.Integer(next.Location);
+                    next = integer.Remainder.ConsumeChar();
+                    yield return Result.Value(BoolExpressionToken.Number, integer.Location, integer.Remainder);
+                }
+                else if (char.IsLetter(next.Value)) {
+                    var variableStart = next.Location;
+                    while ( next.HasValue && char.IsLetterOrDigit(next.Value) ) {
+                        next = next.Remainder.ConsumeChar();
+                    }
+                    yield return Result.Value(BoolExpressionToken.Variable, variableStart, next.Location);
+                }
+                else if (_operators.TryGetValue(next.Value, out charToken)) {
+                    yield return Result.Value(charToken, next.Location, next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                }
+                else {
+                    yield return Result.Empty<BoolExpressionToken>(next.Location, new[] { "number", "variable", "operator" });
+                }
+
+                next = SkipWhiteSpace(next.Location);
+            } while (next.HasValue);
+        }
+    }
+}


### PR DESCRIPTION
Porting a parser from [FParsec](http://www.quanttec.com/fparsec/), I was missing a convenient way to declare in-fix and pre-fix operators in a declarative way, which would handle both operator associativity and operator precedence.

I added some helper classes to assist with this. Consider an example, where we are defining a parser for Boolean expressions. We have the following operators:

| Operator | Association | Precedence |
| ---------- | -------------| ------------- |
| or            | left              | 1                 |
| and         | left              | 2                 |
| <            | left              | 3                 |
| >            | left              | 3                 |
| +            | left              | 4                 |
| -            | left              | 4                 |
| *            | left              | 5                 |
| /            | left              | 5                 |
| not           |             | 6                 |

This would allow us parse expressions like: `2 * i1 + 7 < i2 or i3 > i4 / 2`

One way to ensure that operator precedence is respected, would be to create one parser for each precedence groups above. I would start by calling the parser representing operators with the lowest precedence group. Each parser would call the parser with the precedence group just above it - and the last parser would call a parser representing the atoms in the expression.

This pull request introduce two classes to help express operator precedence and operator associativity:

* `InfixOprGroup`: representing a set of infix operators with same associativity and precedence
* `PrefixOprGroup`: representing a set of prefix operators with same precedence

Each of the classes above implement a common interface `IOperatorGroup`, which declares the method `IOperatorGroup.BuildParser()` for constructing a parser from the definition of the operators, the associativity (in case it is prefix operators) and the precedence.

If we have a mapping representing tokens to the operators used by the resulting abstract syntax tree representing the expression (`TokenToOprMap` in the example below), and if we have a methods for constructing unary and binary expressions, then I can express the entire parser like:

``` C#
private static readonly TokenListParser<BoolExpressionToken, Expression> Expr =
  new List<IOperatorGroup<BoolExpressionToken, Expression>> {
    // OR
    new InfixOprGroup<BoolExpressionToken, Expression, ExpressionType>(
      1, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
      BoolExpressionToken.Or),
    // AND
    new InfixOprGroup<BoolExpressionToken, Expression, ExpressionType>(
      2, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
      BoolExpressionToken.And),
    // LESS-THAN / GREATER-THAN
    new InfixOprGroup<BoolExpressionToken, Expression, ExpressionType>(
      3, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
      BoolExpressionToken.Lt, BoolExpressionToken.Gt),
    // PLUS / MINUS
    new InfixOprGroup<BoolExpressionToken, Expression, ExpressionType>(
      4, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
      BoolExpressionToken.Plus, BoolExpressionToken.Minus),
    // TIMES / DIVIDE
    new InfixOprGroup<BoolExpressionToken, Expression, ExpressionType>(
      5, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
      BoolExpressionToken.Times, BoolExpressionToken.Divide),
    // NOT
    new PrefixOprGroup<BoolExpressionToken,Expression,ExpressionType>(
      6, t => TokenToOprMap[t], (oprType, expr)=>Expression.MakeUnary(oprType,expr,null),
      BoolExpressionToken.Not)
  }.DefineParser(Atom);
```
This extension has made my resulting Superpower parser much easier to read/write. This pull request is posted, in case @nblumhardt believe it could be of general usage.
