### PR TITLE
Chain without recursion

### DIFF
--- a/src/Superpower/Parse.cs
+++ b/src/Superpower/Parse.cs
@@ -41,22 +41,29 @@ namespace Superpower
             if (@operator == null) throw new ArgumentNullException(nameof(@operator));
             if (operand == null) throw new ArgumentNullException(nameof(operand));
             if (apply == null) throw new ArgumentNullException(nameof(apply));
-            return operand.Then(first => ChainOperatorRest(first, @operator, operand, apply));
-        }
 
-        static TextParser<T> ChainOperatorRest<T, TOperator>(
-            T firstOperand,
-            TextParser<TOperator> @operator,
-            TextParser<T> operand,
-            Func<TOperator, T, T, T> apply)
-        {
-            if (@operator == null) throw new ArgumentNullException(nameof(@operator));
-            if (operand == null) throw new ArgumentNullException(nameof(operand));
-            if (apply == null) throw new ArgumentNullException(nameof(apply));
-            return @operator.Then(opvalue =>
-                operand.Then(operandValue =>
-                    ChainOperatorRest(apply(opvalue, firstOperand, operandValue), @operator, operand, apply)))
-                    .Or(Return(firstOperand));
+            return input => {
+                var parseResult = operand(input);
+                if (!parseResult.HasValue) {
+                    return parseResult;
+                }
+
+                var result = parseResult.Value;
+
+                var operatorResult = @operator(parseResult.Remainder);
+                while (operatorResult.HasValue) {
+                    parseResult = operand(operatorResult.Remainder);
+
+                    if (!parseResult.HasValue) {
+                        return Result.CastEmpty<T, T>(parseResult);
+                    }
+
+                    result = apply(operatorResult.Value, result, parseResult.Value);
+                    operatorResult = @operator(parseResult.Remainder);
+                }
+
+                return Result.Value(result, input, parseResult.Remainder);
+            };
         }
 
         /// <summary>
@@ -112,22 +119,30 @@ namespace Superpower
             if (@operator == null) throw new ArgumentNullException(nameof(@operator));
             if (operand == null) throw new ArgumentNullException(nameof(operand));
             if (apply == null) throw new ArgumentNullException(nameof(apply));
-            return operand.Then(first => ChainOperatorRest(first, @operator, operand, apply));
-        }
 
-        static TokenListParser<TKind, T> ChainOperatorRest<TKind, T, TOperator>(
-            T firstOperand,
-            TokenListParser<TKind, TOperator> @operator,
-            TokenListParser<TKind, T> operand,
-            Func<TOperator, T, T, T> apply)
-        {
-            if (@operator == null) throw new ArgumentNullException(nameof(@operator));
-            if (operand == null) throw new ArgumentNullException(nameof(operand));
-            if (apply == null) throw new ArgumentNullException(nameof(apply));
-            return @operator.Then(opvalue =>
-                operand.Then(operandValue =>
-                    ChainOperatorRest(apply(opvalue, firstOperand, operandValue), @operator, operand, apply)))
-                    .Or(Return<TKind, T>(firstOperand));
+            return input =>
+            {
+                var parseResult = operand(input);
+                if ( !parseResult.HasValue ) {
+                    return parseResult;
+                }
+
+                var result = parseResult.Value;
+
+                var operatorResult = @operator(parseResult.Remainder);
+                while (operatorResult.HasValue) {
+                    parseResult = operand(operatorResult.Remainder);
+
+                    if (!parseResult.HasValue) {
+                        return TokenListParserResult.CastEmpty<TKind, T, T>(parseResult);
+                    }
+
+                    result = apply(operatorResult.Value, result, parseResult.Value);
+                    operatorResult = @operator(parseResult.Remainder);
+                }
+
+                return TokenListParserResult.Value(result, input, parseResult.Remainder);
+            };
         }
 
         /// <summary>

--- a/src/Superpower/Parse.cs
+++ b/src/Superpower/Parse.cs
@@ -51,11 +51,17 @@ namespace Superpower
                 var result = parseResult.Value;
 
                 var operatorResult = @operator(parseResult.Remainder);
-                while (operatorResult.HasValue) {
+                while (operatorResult.HasValue || operatorResult.IsPartial(parseResult.Remainder)) {
+                    // If operator read any input, but failed to read complete input, we return error
+                    if (!operatorResult.HasValue) {
+                        return Result.CastEmpty<TOperator,T>(operatorResult);
+                    }
+
+
                     parseResult = operand(operatorResult.Remainder);
 
                     if (!parseResult.HasValue) {
-                        return Result.CastEmpty<T, T>(parseResult);
+                        return parseResult;
                     }
 
                     result = apply(operatorResult.Value, result, parseResult.Value);
@@ -130,7 +136,12 @@ namespace Superpower
                 var result = parseResult.Value;
 
                 var operatorResult = @operator(parseResult.Remainder);
-                while (operatorResult.HasValue) {
+                while (operatorResult.HasValue || operatorResult.IsPartial(parseResult.Remainder)) {
+                    // If operator read any input, but failed to read complete input, we return error
+                    if (!operatorResult.HasValue) {
+                        return TokenListParserResult.CastEmpty<TKind, TOperator, T>(operatorResult);
+                    }
+
                     parseResult = operand(operatorResult.Remainder);
 
                     if (!parseResult.HasValue) {

--- a/test/Superpower.Tests/Combinators/ChainCombinatorTests.cs
+++ b/test/Superpower.Tests/Combinators/ChainCombinatorTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Superpower.Parsers;
 using Superpower.Tests.Support;
 using Xunit;
@@ -12,18 +11,53 @@ namespace Superpower.Tests.Combinators
         public void SuccessWithLongChains()
         {
             const int chainLength = 5000;
-            string input = string.Join( "+",  Enumerable.Repeat("1", chainLength ) );
-            AssertParser.SucceedsWith( Parse.Chain( Character.EqualTo('+'),
-                Numerics.IntegerInt32, (opr,val1,val2) => val1 + val2 ), input, chainLength );
+            string input = string.Join("+", Enumerable.Repeat("1", chainLength));
+            var chainParser = Parse.Chain(
+                Character.EqualTo('+'),
+                Numerics.IntegerInt32,
+                (opr, val1, val2) => val1 + val2);
+
+            AssertParser.SucceedsWith(chainParser, input, chainLength);
         }
 
         [Fact]
-        public void TokenSuccessWithLongChains() {
+        public void TokenSuccessWithLongChains()
+        {
             const int chainLength = 5000;
-            string input = string.Join( "+", Enumerable.Repeat( "1", chainLength ) );
+            string input = string.Join("+", Enumerable.Repeat("1", chainLength));
 
-            AssertParser.SucceedsWith( Parse.Chain(
-                Token.EqualTo( '+' ), Token.EqualTo( '1' ).Value( 1 ), ( opr, val1, val2 ) => val1 + val2 ), input, chainLength );
+            var chainParser = Parse.Chain(
+                Token.EqualTo('+'),
+                Token.EqualTo('1').Value(1),
+                (opr, val1, val2) => val1 + val2);
+
+            AssertParser.SucceedsWith(chainParser, input, chainLength);
         }
-  }
+
+        [Fact]
+        public void ChainFailWithMultiTokenOperator()
+        {
+            // Addition is represented with operator '++'
+            // If we only have one '+', ensure we get error
+            var nPlusPlusN = Parse.Chain(
+                Character.EqualTo('+').IgnoreThen(Character.EqualTo('+')),
+                Numerics.IntegerInt32,
+                (opr, val1, val2) => val1 + val2);
+
+            AssertParser.FailsAt(nPlusPlusN, "1+1", 2);
+        }
+
+        [Fact]
+        public void TokenChainFailWithMultiTokenOperator()
+        {
+            // Addition is represented with operator '++'
+            // If we only have one '+', ensure we get error
+            var nPlusPlusN = Parse.Chain(
+                Token.EqualTo('+').IgnoreThen(Token.EqualTo('+')),
+                Token.EqualTo('1').Value(1),
+                (opr, val1, val2) => val1 + val2);
+
+            AssertParser.FailsAt(nPlusPlusN, "1+1", 2);
+        }
+    }
 }

--- a/test/Superpower.Tests/Combinators/ChainCombinatorTests.cs
+++ b/test/Superpower.Tests/Combinators/ChainCombinatorTests.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Linq;
+using Superpower.Parsers;
+using Superpower.Tests.Support;
+using Xunit;
+
+namespace Superpower.Tests.Combinators
+{
+    public class ChainCombinatorTests
+    {
+        [Fact]
+        public void SuccessWithLongChains()
+        {
+            const int chainLength = 5000;
+            string input = string.Join( "+",  Enumerable.Repeat("1", chainLength ) );
+            AssertParser.SucceedsWith( Parse.Chain( Character.EqualTo('+'),
+                Numerics.IntegerInt32, (opr,val1,val2) => val1 + val2 ), input, chainLength );
+        }
+
+        [Fact]
+        public void TokenSuccessWithLongChains() {
+            const int chainLength = 5000;
+            string input = string.Join( "+", Enumerable.Repeat( "1", chainLength ) );
+
+            AssertParser.SucceedsWith( Parse.Chain(
+                Token.EqualTo( '+' ), Token.EqualTo( '1' ).Value( 1 ), ( opr, val1, val2 ) => val1 + val2 ), input, chainLength );
+        }
+  }
+}


### PR DESCRIPTION
The current `Parse.Chain()` operator is implemented using recursion. When applied to expressions with moderate size chain of operands and operators, this can cause a stack-overflow.

This pull request changes the implementation of `Parse.Chain()` to an iterative approach, avoiding stack-overflow exceptions.

Attached unit test show how to provoke the stack overflow exception.