### PR TITLE
Initial api suggestion to add TextSpan.ConsumeRegex

### DIFF
--- a/src/Superpower/Model/Position.cs
+++ b/src/Superpower/Model/Position.cs
@@ -88,5 +88,15 @@ namespace Superpower.Model
         {
             return $"{Absolute} (line {Line}, column {Column})";
         }
+
+        internal Position Advance(string overString)
+        {
+            // TODO: avoid creating intermediate Position object 
+            // by folding the logic of Advance(char) into the loop
+            var current = this;
+            foreach (var chr in overString)
+                current = current.Advance(chr);
+            return current;
+        }
     }
 }

--- a/src/Superpower/Model/TextSpan.cs
+++ b/src/Superpower/Model/TextSpan.cs
@@ -109,6 +109,32 @@ namespace Superpower.Model
             return Result.Value(ch, this, new TextSpan(Source, Position.Advance(ch), Length - 1));
         }
 
+        /// <summary>
+        /// Consume the charcters that match a regex
+        /// </summary>
+        /// <param name="regex"></param>
+        /// <returns></returns>
+        internal Result<string> ConsumeRegex(string regex)
+        {
+            EnsureHasValue();
+            if (IsAtEnd)
+                return Result.Empty<string>(this);
+
+            var re = new System.Text.RegularExpressions.Regex($"\\G({regex})");
+            var match = re.Match(this.Source, this.Position.Absolute);
+
+            if (match.Success)
+            {
+                var value = match.Value;
+                return Result.Value(value, this, new TextSpan(Source, Position.Advance(value), Length - value.Length));
+            }
+            else
+            {
+                return Result.Empty<string>(this);
+            }
+        }
+
+
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {

--- a/test/Superpower.Tests/StringSpanTests.cs
+++ b/test/Superpower.Tests/StringSpanTests.cs
@@ -44,5 +44,30 @@ namespace Superpower.Tests
             var span = new TextSpan(str, new Position(offset, 1, offset + 1), length);
             Assert.False(span.EqualsValue(value));
         }
+
+
+        [Theory]
+        [InlineData("Hello World", 0, 11, "Hello|World", "Hello")]
+        [InlineData("Hello World", 6, 5, "Hello|World", "World")]
+        public void ASpanReturnsExpectedWhenConsumingRegex(string str, int offset, int length, string regex, string expected)
+        {
+            var span = new TextSpan(str, new Position(offset, 1, offset + 1), length);
+
+            var actual = span.ConsumeRegex(regex);
+
+            Assert.Equal(expected, actual.Value);
+        }
+
+        [Theory]
+        [InlineData("Hello World", 0, 11, "Help|Stop")] // Help partially matches but should fail nonetheless
+        [InlineData("Prefix Hello World", 0, 11, "Hello|World")] // Would only match if prefix gets skiped (i.e. regex is not anchored on current position)
+        public void ASpanReturnsExpectedFailureWhenRegexDoesNotMatch(string str, int offset, int length, string regex)
+        {
+            var span = new TextSpan(str, new Position(offset, 1, offset + 1), length);
+
+            var actual = span.ConsumeRegex(regex);
+
+            Assert.False(actual.HasValue);
+        }
     }
 }


### PR DESCRIPTION
Hello Nicholas,
 
I saw a discussion about Keyword Tokens and suggest to have something like
`current.ConsumeRegex("if|then|else");` in the tokenizer. 
Under the cover it uses an anchored regular expression and advances the text span multiple characters at ones.

The pull request has a minimal implementation with little test coverage. I understand it would need more tests including some performance test. I would love to finish that, but wanted to get that in front of you, and hear what you generally think about the idea to mix the Regex paradigm into the tokenizer.

Christof