### PR TITLE
Support for creating an empty result based on expected tokens

### DIFF
--- a/src/Superpower/Model/TokenListParserResult.cs
+++ b/src/Superpower/Model/TokenListParserResult.cs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Linq;
+using Superpower.Display;
+
 namespace Superpower.Model
 {
     /// <summary>
@@ -42,6 +45,20 @@ namespace Superpower.Model
         public static TokenListParserResult<TKind, T> Empty<TKind, T>(TokenList<TKind> remainder, string[] expectations)
         {
             return new TokenListParserResult<TKind, T>(remainder, Position.Empty, null, expectations, false);
+        }
+
+        /// <summary>
+        /// Create a token result with no value, indicating a failure to parse any value.
+        /// </summary>
+        /// <typeparam name="TKind">The kind of token.</typeparam>
+        /// <typeparam name="T">The result type.</typeparam>
+        /// <param name="remainder">The start of un-parsed input.</param>
+        /// <param name="expectations">Expectations that could not be fulfilled.</param>
+        /// <returns>An empty result.</returns>
+        public static TokenListParserResult<TKind, T> Empty<TKind, T>(TokenList<TKind> remainder, TKind[] expectations)
+        {
+            var stringExpectations = expectations.Select(Presentation.FormatExpectation).ToArray();
+            return new TokenListParserResult<TKind, T>(remainder, Position.Empty, null, stringExpectations, false);
         }
 
         /// <summary>

--- a/test/Superpower.Tests/ErrorMessageScenarioTests.cs
+++ b/test/Superpower.Tests/ErrorMessageScenarioTests.cs
@@ -1,4 +1,5 @@
-﻿using Superpower.Parsers;
+﻿using Superpower.Model;
+using Superpower.Parsers;
 using Superpower.Tests.ArithmeticExpressionScenario;
 using Superpower.Tests.SExpressionScenario;
 using Superpower.Tests.Support;
@@ -13,9 +14,9 @@ namespace Superpower.Tests
         {
             var number = Token.EqualTo(SExpressionToken.Number)
                   .Apply(t => Character.EqualTo('1').Then(_ => Character.EqualTo('x')));
-            
+
             var numbers = number.AtEnd();
-            
+
             AssertParser.FailsWithMessage(numbers, "123", new SExpressionTokenizer(),
                 "Syntax error (line 1, column 2): invalid number, unexpected `2`, expected `x`.");
         }
@@ -115,6 +116,26 @@ namespace Superpower.Tests
             var equalToA = Span.EqualToIgnoreCase('a');
             AssertParser.FailsWithMessage(equalToA, "",
                 "Syntax error: unexpected end of input, expected `a`.");
+        }
+
+        [Fact]
+        public void MessageWithExpectedTokensUsesTokenPresentation()
+        {
+            // Composing a complex parser which does not fit a LALR(1) grammar, one might need
+            // to have multiple look-ahead tokens. While it is possible to compose parsers with back-tracking,
+            // manual generated parsers are some times easier to construct. These parsers would like
+            // to report expectations using tokens, but still benefit from the annotations put on
+            // the tokens, to generated nicely formatted error messages. The following construct
+            // shows how to generate an empty result, which indicates which tokens are expected.
+            var emptyParseResult = TokenListParserResult.Empty<ArithmeticExpressionToken, string>(
+                new TokenList<ArithmeticExpressionToken>(),
+                new []{ ArithmeticExpressionToken.Times, ArithmeticExpressionToken.Zero});
+
+            // Empty result represent expectations using nice string representation taken from
+            // annotations of enum values of tokens
+            Assert.Equal(2, emptyParseResult.Expectations.Length);
+            Assert.Equal( "`*`", emptyParseResult.Expectations[0]);
+            Assert.Equal("`zero`", emptyParseResult.Expectations[1]);
         }
     }
 }


### PR DESCRIPTION
Open support for creating an empty `TokenListParserResult`, describing that one in a set of specific tokens were expected.

This method allow consumers to use the internal `Presentation.FormatExpectation`, to create a nice presentation for tokens which are expected.