### PR TITLE
Operator precedence parser for simple expressions

### DIFF
--- a/src/Superpower/OperatorPrecedenceParser/ExprSetDef.cs
+++ b/src/Superpower/OperatorPrecedenceParser/ExprSetDef.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Superpower.OperatorPrecedenceParser
+{
+    /// <summary>
+    /// Definition of a set of expressions
+    /// </summary>
+    public class ExprSetDef<TKind, T> : IExprDef<TKind>
+    {
+        /// <summary>
+        /// <para>
+        /// Construct a new <see cref="ExprSetDef{TKind,T}"/> representing
+        /// a set of expression. </para>
+        /// <para>The most simple form for set is the singleton set that does not
+        /// have any <paramref name="separators"/> - this could e.g. use to define
+        /// an expression in parenthesis.</para>
+        /// </summary>
+        /// <param name="setStart">Token defining the start of a set</param>
+        /// <param name="setEnd">Token defining the end of the set</param>
+        /// <param name="separators">A collection of allowed separators between elements in the set.
+        /// If this is set to null, then only singleton sets are accepted.</param>
+        /// <param name="allowEmptySet">If set to true, will allow the empty set.</param>
+        /// <param name="resultBuilder">Function for creating result of type <typeparamref name="T"/> given
+        /// list of operands and list of separators. If set to null, then
+        /// <paramref name="separators"/> must be empty/null, and the function used will
+        /// be the identity function, simply returning the singleton operand as the result.
+        /// </param>
+        /// <param name="canBuild">Optional function to validate that operands and separators can
+        /// build into a result of type <typeparamref name="T"/>. If this function is given,
+        /// the function is called before trying to build a result. If the function returns any string
+        /// but null, it is considered an error message, which is reported in a parse exception.</param>
+        public ExprSetDef(
+            TKind setStart,
+            TKind setEnd,
+            IEnumerable<TKind> separators = null,
+            bool allowEmptySet = false,
+            Func<IEnumerable<T>, IEnumerable<TKind>, T> resultBuilder = null,
+            Func<IEnumerable<T>, IEnumerable<TKind>, string> canBuild = null)
+        {
+            SetStart = setStart;
+            SetEnd = setEnd;
+            AllowEmptySet = allowEmptySet;
+            CanBuild = canBuild ?? ( (operands, seps) => null );
+            Separators = separators?.ToArray() ?? new TKind[0];
+
+            if ( resultBuilder == null && Separators.Count > 0 ) {
+                throw new ArgumentException(
+                    "A set where separators are defined must also define a function for mapping operands into a result.");
+            }
+
+            ResultBuilder = resultBuilder ?? ( (operands, seps) => operands.First() );
+        }
+
+        /// <summary>
+        /// Return true if <paramref name="token"/> is either defined in
+        /// <see cref="Separators"/> or as <see cref="SetEnd"/>
+        /// </summary>
+        public bool IsSeparatorOrEnd(TKind token) =>
+            SetEnd.Equals(token) || Separators.Contains(token);
+
+        /// <summary>
+        /// Return true if <paramref name="token"/> is either defined in
+        /// <see cref="Separators"/> or as <see cref="SetStart"/>
+        /// </summary>
+        public bool IsSeparatorOrStart(TKind token) =>
+            SetStart.Equals(token) || Separators.Contains(token);
+
+        /// <summary>
+        /// Token defining the start of the set
+        /// </summary>
+        public TKind SetStart { get; }
+
+        /// <summary>
+        /// Token defining the end of the set
+        /// </summary>
+        public TKind SetEnd { get; }
+
+        /// <summary>
+        /// If set to true, will allow the empty set
+        /// </summary>
+        public bool AllowEmptySet { get; }
+
+        /// <summary>
+        /// Function to validate that operands and separators can
+        /// build into a result of type <typeparamref name="T"/>. This function
+        /// is called before trying to build a result. If the function returns any string
+        /// but null, it is considered an error message, which is reported in a parse exception.
+        /// </summary>
+        public Func<IEnumerable<T>, IEnumerable<TKind>, string> CanBuild { get; }
+
+        /// <summary>
+        /// Tokens used to separate operands
+        /// </summary>
+        public IReadOnlyList<TKind> Separators { get; }
+
+        /// <summary>
+        /// Function for creating result of type <typeparamref name="T"/> based on
+        /// a collection of input operands and a set of separators.
+        /// </summary>
+        public Func<IEnumerable<T>, IEnumerable<TKind>, T> ResultBuilder { get; }
+
+        /// <inheritdoc />
+        public int Precedence => 0;
+    }
+}

--- a/src/Superpower/OperatorPrecedenceParser/IExprDef.cs
+++ b/src/Superpower/OperatorPrecedenceParser/IExprDef.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace Superpower.OperatorPrecedenceParser
+{
+    /// <summary>
+    /// Marker interface used to describe a valid part of an expression, used
+    /// when defining a operator precedence parser with the <see cref="OperatorPrecedenceParser{TKind,T,U}"/>
+    /// class.
+    /// </summary>
+    /// <typeparam name="TKind">Type of tokens parsed</typeparam>
+    internal interface IExprDef<TKind>
+    {
+        /// <summary>
+        /// Precedence of expressions represented by this definition. For
+        /// operators, the precedence define how "hard" the operator binds.
+        /// </summary>
+        int Precedence { get; }
+    }
+
+    /// <summary>
+    /// Part of an expression representing a prefix or infix operator
+    /// </summary>
+    internal interface IExprOprDef<TKind> : IExprDef<TKind>
+    {
+        /// <summary>
+        /// Tokens representing operators in this group
+        /// </summary>
+        IReadOnlyList<TKind> Tokens { get; set; }
+    }
+}

--- a/src/Superpower/OperatorPrecedenceParser/IfThenElseDef.cs
+++ b/src/Superpower/OperatorPrecedenceParser/IfThenElseDef.cs
@@ -1,0 +1,68 @@
+﻿using System;
+
+namespace Superpower.OperatorPrecedenceParser
+{
+    /// <summary>
+    /// <para>Definition of If-Then-Else expressions, where the else part is optional.</para>
+    /// <para>The Else part will bind to the nearest If part, in case If-Then-Else expressions
+    /// are nested.</para>
+    /// </summary>
+    /// <typeparam name="TKind">Type of tokens parsed</typeparam>
+    /// <typeparam name="T">Type of result output by parser</typeparam>
+    public class IfThenElseDef<TKind, T> : IExprDef<TKind>
+    {
+        /// <summary>
+        /// Construct a new <see cref="IfThenElseDef{TKind,T}"/> representing expression written
+        /// as IF condition THEN when-true ELSE when-false
+        /// </summary>
+        /// <param name="ifToken">Token to appear before condition</param>
+        /// <param name="thenToken">Token to appear before when-true</param>
+        /// <param name="elseToken">Token to appear before when-false</param>
+        /// <param name="buildIfThenElseResult"></param>
+        /// <param name="buildIfThenResult"></param>
+        public IfThenElseDef(
+            TKind ifToken,
+            TKind thenToken,
+            TKind elseToken,
+            Func<T, T, T, T> buildIfThenElseResult,
+            Func<T, T, T> buildIfThenResult)
+        {
+
+            IfToken = ifToken;
+            ThenToken = thenToken;
+            ElseToken = elseToken;
+            BuildIfThenElseResult = buildIfThenElseResult;
+            BuildIfThenResult = buildIfThenResult;
+        }
+
+        /// <summary>
+        /// Function for building If-Then-Else expression from condition,
+        /// when-true and when-false
+        /// </summary>
+        public Func<T, T, T, T> BuildIfThenElseResult { get; }
+
+        /// <summary>
+        /// Function for building If-Then expression from condition
+        /// and when-true
+        /// </summary>
+        public Func<T, T, T> BuildIfThenResult { get; }
+
+        /// <summary>
+        /// Token representing beginning of IF part of expression
+        /// </summary>
+        public TKind IfToken { get; }
+
+        /// <summary>
+        /// Token representing beginning of THEN part of expression
+        /// </summary>
+        public TKind ThenToken { get; }
+
+        /// <summary>
+        /// Token representing beginning of ELSE part of expression
+        /// </summary>
+        public TKind ElseToken { get; }
+
+        /// <inheritdoc />
+        public int Precedence { get; } = 0;
+    }
+}

--- a/src/Superpower/OperatorPrecedenceParser/InfixOprAssociativity.cs
+++ b/src/Superpower/OperatorPrecedenceParser/InfixOprAssociativity.cs
@@ -1,0 +1,18 @@
+﻿namespace Superpower.OperatorPrecedenceParser
+{
+    /// <summary>
+    /// Defines is the associativity (left or right) or a binary infix operator
+    /// </summary>
+    public enum InfixOprAssociativity
+    {
+        /// <summary>
+        /// Operator is left associative
+        /// </summary>
+        Left,
+
+        /// <summary>
+        /// Operator is right associative
+        /// </summary>
+        Right
+    }
+}

--- a/src/Superpower/OperatorPrecedenceParser/InfixOprDef.cs
+++ b/src/Superpower/OperatorPrecedenceParser/InfixOprDef.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Superpower.OperatorPrecedenceParser
+{
+    /// <summary>
+    /// Definition of binary infix operators
+    /// </summary>
+    /// <typeparam name="TKind">Type of tokens parsed</typeparam>
+    /// <typeparam name="T">Type of result output by parser</typeparam>
+    /// <typeparam name="U">Type of binary operators which tokens are transformed into</typeparam>
+    internal class InfixOprDef<TKind, T, U> : IExprOprDef<TKind>
+    {
+
+        /// <summary>
+        /// Create an <see cref="InfixOprDef{TKind,T,U}"/> representing a group of infix
+        /// operators with same <see cref="Precedence"/>.
+        /// </summary>
+        /// <param name="precedence">Operator precedence of all operators specified</param>
+        /// <param name="associativity">Specification if operators are left or right associative</param>
+        /// <param name="tokenToOperator">Function for transforming token of type <typeparamref name="TKind"/>
+        /// into binary operator of type <typeparamref name="U"/></param>
+        /// <param name="resultBuilder">Function for creating result of type <typeparamref name="T"/>
+        /// given an operator of type <typeparamref name="U"/> and two arguments of type
+        /// <typeparamref name="T"/></param>
+        /// <param name="tokens">Tokens representing operators in this operator group</param>
+        public InfixOprDef(
+            int precedence,
+            InfixOprAssociativity associativity,
+            Func<TKind, U> tokenToOperator,
+            Func<U, T, T, T> resultBuilder,
+            params TKind[] tokens)
+        {
+            Precedence = precedence;
+            Tokens = tokens;
+            Associativity = associativity;
+
+            TokenToOperator = tokenToOperator;
+            ResultBuilder = resultBuilder;
+
+            // Validate that token mapping works
+            foreach ( var token in tokens ) {
+                try {
+                    tokenToOperator(token);
+                }
+                catch {
+                    throw new InvalidDataException($"Token {token} is not mapped correctly");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Method for mapping two operands into a single operand using provided operator
+        /// </summary>
+        public Func<U, T, T, T> ResultBuilder { get; set; }
+
+        /// <summary>
+        /// Indication if operator is left of right associative
+        /// </summary>
+        public InfixOprAssociativity Associativity { get; set; }
+
+        /// <summary>
+        /// Mapping from tokens in <see cref="Tokens"/> to operator of type <typeparamref name="U"/>
+        /// </summary>
+
+        public Func<TKind, U> TokenToOperator { get; set; }
+
+
+        /// <inheritdoc />
+        public IReadOnlyList<TKind> Tokens { get; set; }
+
+
+        /// <inheritdoc />
+        public int Precedence { get; }
+    }
+}

--- a/src/Superpower/OperatorPrecedenceParser/OperatorPrecedenceParser.cs
+++ b/src/Superpower/OperatorPrecedenceParser/OperatorPrecedenceParser.cs
@@ -1,0 +1,577 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Superpower.Display;
+using Superpower.Model;
+
+namespace Superpower.OperatorPrecedenceParser
+{
+
+    /// <summary>
+    /// <para>An operator precedence parser is a bottom-up parser accepting simple grammars describing
+    /// expressions. This type of parser can be used for expressions with grammars where no production
+    /// rule leads to empty input, and where no production rule has two adjacent non-terminal symbols.
+    /// </para>
+    /// <para>
+    /// This implementation allow a grammar to be represented by <see cref="IExprDef{TKind}"/>
+    /// constructs, providing support for infix operators, prefix operators, sets of
+    /// expressions (including singleton sets, such as parenthesis) and if-then-else
+    /// constructs.</para>
+    /// <para>The parser is implemented using a stack, with shift/reduce actions. As such, this
+    /// type of parser is not prone to stack-overflow exceptions when parsing
+    /// deeply nested expressions.
+    /// </para>
+    /// <para>The same token can be used to define both a prefix and an infix operator (e.g.
+    /// a MINUS token representing infix subtraction and prefix negation), but any token
+    /// used to define a set or if-then-else construct cannot also be used
+    /// to define a prefix/infix operator.</para>
+    /// </summary>
+    /// <typeparam name="TKind">Type of input token</typeparam>
+    /// <typeparam name="T">Resulting types</typeparam>
+    /// <typeparam name="U">Type of operator used to combine the resulting operands of type <typeparamref name="T"/>
+    /// into new operands when handling prefix and infix operators</typeparam>
+    internal class OperatorPrecedenceParser<TKind, T, U>
+    {
+        private static readonly TokenListParserResult<TKind, T>
+            EmptyParseResult = new TokenListParserResult<TKind, T>();
+
+        private static readonly TKind EmptyToken = default(TKind);
+        private static readonly IExprDef<TKind> EmptyExprDef = default(IExprDef<TKind>);
+
+        private readonly TokenListParser<TKind, T> _operandParser;
+
+        private readonly Dictionary<TKind, PrefixOprDef<TKind, T, U>> _prefixOperators;
+        private readonly Dictionary<TKind, InfixOprDef<TKind, T, U>> _infixOperators;
+        private readonly Dictionary<TKind, ExprSetDef<TKind, T>> _setDefinitions;
+        private readonly Dictionary<TKind, IfThenElseDef<TKind, T>> _iteDefinitions;
+
+        /// <summary>
+        /// Definition of what has been read from input
+        /// </summary>
+        private enum ResultType
+        {
+            Error,
+            EndOfInput,
+            Operand,
+            Operator,
+            Set,
+            IfThenElse
+        }
+
+        /// <summary>
+        /// Definition of shift vs reduce operation
+        /// </summary>
+        private enum ShiftReduce
+        {
+            Shift,
+            Reduce
+        }
+
+        /// <summary>
+        /// Data read from input
+        /// </summary>
+        private struct NextResult
+        {
+            public NextResult(
+                ResultType resultType,
+                TKind token,
+                IExprDef<TKind> exprDef,
+                TokenListParserResult<TKind, T> parseResult)
+            {
+
+                ResultType = resultType;
+                Token = token;
+                ExprDef = exprDef;
+                ParseResult = parseResult;
+            }
+
+            public ResultType ResultType { get; }
+
+            public TKind Token { get; }
+
+            public IExprDef<TKind> ExprDef { get; }
+
+            public TokenListParserResult<TKind, T> ParseResult { get; }
+        }
+
+        /// <summary>
+        /// Definition of what is expected next. Used to detect errors in
+        /// input.
+        /// </summary>
+        private struct ExpectedNext
+        {
+            public bool ExpectOperand { get; set; }
+
+            public Stack<ExprSetDef<TKind, T>> OpenSet { get; set; }
+
+            public Stack<(TKind token, IfThenElseDef<TKind, T> iteDef)> OpenIte { get; set; }
+        }
+
+        /// <summary>
+        /// Construct an operator precedence parser capable of parsing expressions described
+        /// by <paramref name="exprDefs"/>. The operands for the parser are defined
+        /// by the <paramref name="operandParser"/>. Note that the <paramref name="operandParser"/>
+        /// should not accept the empty token set.
+        /// </summary>
+        public static TokenListParser<TKind, T> DefineParser(
+            IEnumerable<IExprDef<TKind>> exprDefs,
+            TokenListParser<TKind, T> operandParser)
+        {
+            var parser = new OperatorPrecedenceParser<TKind, T, U>(exprDefs, operandParser);
+
+            return input => parser.Parse(input);
+        }
+
+        private OperatorPrecedenceParser(
+            IEnumerable<IExprDef<TKind>> exprDefs,
+            TokenListParser<TKind, T> operandParser)
+        {
+
+            _operandParser = operandParser;
+
+            var exprDefsList = exprDefs.ToList();
+
+            _infixOperators = exprDefsList
+                .OfType<InfixOprDef<TKind, T, U>>()
+                .SelectMany(opr => opr.Tokens.Select(t => ( t, opr )))
+                .ToDictionary(t => t.Item1, t => t.Item2);
+
+            _prefixOperators = exprDefsList
+                .OfType<PrefixOprDef<TKind, T, U>>()
+                .SelectMany(opr => opr.Tokens.Select(t => (t, opr)))
+                .ToDictionary(t => t.Item1, t => t.Item2);
+
+            _setDefinitions = exprDefsList
+                .OfType<ExprSetDef<TKind, T>>()
+                .SelectMany(set => set.Separators.Concat(new[] { set.SetStart, set.SetEnd }).Select(t => (t, set)))
+                .ToDictionary(t => t.Item1, t => t.Item2);
+
+            _iteDefinitions = exprDefsList
+                .OfType<IfThenElseDef<TKind, T>>()
+                .SelectMany(ite => new[] { (ite.IfToken, ite), (ite.ThenToken, ite), (ite.ElseToken, ite) })
+                .ToDictionary(t => t.Item1, t => t.Item2);
+
+            // We allow same token to represent infix/prefix operator, set and if-then-else tokens must be used only once
+            var tokenOverlap =
+                _setDefinitions.Keys.Concat(_iteDefinitions.Keys)
+                    .Concat(_infixOperators.Keys.Union(_prefixOperators.Keys))
+                    .GroupBy(t => t)
+                    .Where(g => g.Count() > 1)
+                    .Select(g => g.Key)
+                    .ToArray();
+            if ( tokenOverlap.Any() ) {
+                throw new ArgumentException(
+                    $"Tokens used in sets/if-then-else expression definitions cannot be used more than once: {string.Join(",", tokenOverlap)}");
+            }
+        }
+
+        /// <summary>
+        /// Parse expression
+        /// </summary>
+        public TokenListParserResult<TKind, T> Parse(TokenList<TKind> input)
+        {
+            var operatorStack = new Stack<(TKind token, IExprDef<TKind> exprDef)>();
+            var operandStack = new Stack<T>();
+
+            var next = input.ConsumeToken();
+            var expectedNext = new ExpectedNext {
+                ExpectOperand = true,
+                OpenSet = new Stack<ExprSetDef<TKind, T>>(),
+                OpenIte = new Stack<(TKind, IfThenElseDef<TKind, T>)>()
+            };
+
+            do {
+                var nextResult = ReadNext(ref next, ref expectedNext);
+
+                switch ( nextResult.ResultType ) {
+
+                    case ResultType.Error:
+                        return nextResult.ParseResult;
+
+                    case ResultType.EndOfInput:
+                        ReduceWhile(operatorStack, operandStack, oprStack => oprStack.Count > 0);
+
+                        return TokenListParserResult.Value(operandStack.Pop(), input, next.Location);
+
+                    case ResultType.Operand:
+                        operandStack.Push(nextResult.ParseResult.Value);
+                        break;
+
+                    case ResultType.Operator:
+                        ReduceWhile(operatorStack, operandStack,
+                            oprStack => ShiftOrReduce(oprStack, nextResult.ExprDef) == ShiftReduce.Reduce);
+                        Shift(operatorStack, nextResult);
+
+                        break;
+
+                    case ResultType.Set:
+                        var setDef = (ExprSetDef<TKind, T>) nextResult.ExprDef;
+                        // Start of new set
+                        if ( setDef.SetStart.Equals(nextResult.Token) ) {
+                            Shift(operatorStack, nextResult);
+                        }
+                        // Finding a separator, we reduce last element in set
+                        else if ( setDef.Separators.Contains(nextResult.Token) ) {
+                            ReduceWhile(operatorStack, operandStack,
+                                oprStack => !setDef.IsSeparatorOrStart(oprStack.Peek().token));
+                            Shift(operatorStack, nextResult);
+                        }
+                        // End of set
+                        else {
+                            // If we get the empty token, then the set is empty (and we have not gotten a start operator)
+                            if ( nextResult.Token.Equals(EmptyToken) ) {
+                                operandStack.Push(setDef.ResultBuilder(new T[0], new TKind[0]));
+                                break;
+                            }
+
+                            // Set is not empty, reduce last operand
+                            ReduceWhile(operatorStack, operandStack,
+                                oprStack => !setDef.IsSeparatorOrStart(oprStack.Peek().token));
+
+                            var operands = new List<T>();
+                            var separators = new List<TKind>();
+
+                            while ( !setDef.SetStart.Equals(operatorStack.Peek().token) ) {
+                                operands.Add(operandStack.Pop());
+                                separators.Add(operatorStack.Pop().token);
+                            }
+
+                            // There is one more operand than separator.
+                            operands.Add(operandStack.Pop());
+
+                            // Pop set start
+                            PopExpected(operatorStack, setDef.SetStart);
+
+                            operands.Reverse();
+                            separators.Reverse();
+
+                            // Check that parsed operands and separators are valid
+                            var error = setDef.CanBuild(operands, separators);
+                            if ( error != null ) {
+                                return TokenListParserResult.Empty<TKind, T>(next.Location, error);
+                            }
+
+                            operandStack.Push(setDef.ResultBuilder(operands, separators));
+                        }
+
+                        break;
+
+                    case ResultType.IfThenElse:
+                        var iteDef = (IfThenElseDef<TKind, T>) nextResult.ExprDef;
+                        // When we get THEN / ELSE we reduce as much as possible (to next IF / THEN)
+                        if ( iteDef.ThenToken.Equals(nextResult.Token) ) {
+                            ReduceWhile(operatorStack, operandStack,
+                                oprStack => !iteDef.IfToken.Equals(oprStack.Peek().token));
+                        }
+                        else if ( iteDef.ElseToken.Equals(nextResult.Token) ) {
+                            ReduceWhile(operatorStack, operandStack,
+                                oprStack => !iteDef.ThenToken.Equals(oprStack.Peek().token));
+                        }
+
+                        Shift(operatorStack, nextResult);
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            } while ( true );
+        }
+
+        /// <summary>
+        /// Keep reducing while <paramref name="condition"/> is satisfied
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ReduceWhile(
+            Stack<(TKind token, IExprDef<TKind> exprDef)> operatorStack,
+            Stack<T> operandStack,
+            Func<Stack<(TKind token, IExprDef<TKind> exprDef)>, bool> condition)
+        {
+
+            while ( condition(operatorStack) ) {
+                Reduce(operatorStack, operandStack);
+            }
+        }
+
+        /// <summary>
+        /// Reduce top-most operator on <paramref name="operatorStack"/>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void Reduce(Stack<(TKind token, IExprDef<TKind> exprDef)> operatorStack, Stack<T> operandStack)
+        {
+            var topOpr = operatorStack.Pop();
+
+            // Infix operator
+            if ( topOpr.exprDef is InfixOprDef<TKind, T, U> infixOpr ) {
+                var right = operandStack.Pop();
+                var left = operandStack.Pop();
+
+                operandStack.Push(infixOpr.ResultBuilder(infixOpr.TokenToOperator(topOpr.token), left, right));
+                return;
+            }
+
+            // Prefix operator
+            if ( topOpr.exprDef is PrefixOprDef<TKind, T, U> prefixOpr ) {
+                operandStack.Push(prefixOpr.ResultBuilder(prefixOpr.TokenToOperator(topOpr.token), operandStack.Pop()));
+                return;
+            }
+
+            // If-Then-Else
+            if ( topOpr.exprDef is IfThenElseDef<TKind, T> iteDef ) {
+                T whenFalse = default(T);
+                bool haveElsePart = false;
+
+                if ( topOpr.token.Equals(iteDef.ElseToken) ) {
+                    haveElsePart = true;
+                    whenFalse = operandStack.Pop();
+
+                    PopExpected(operatorStack, iteDef.ThenToken, "Operand for THEN part has not been reduced");
+                }
+
+                PopExpected(operatorStack, iteDef.IfToken, "Operand for IF part has not been reduced");
+
+                var whenTrue = operandStack.Pop();
+                var condition = operandStack.Pop();
+
+                operandStack.Push(haveElsePart ?
+                    iteDef.BuildIfThenElseResult(condition, whenTrue, whenFalse) :
+                    iteDef.BuildIfThenResult(condition, whenTrue));
+                return;
+            }
+
+            throw new InvalidOperationException(
+                "Reduce is called when top of operator stack does not contain a prefix/infix/if-then-else operator");
+        }
+
+        /// <summary>
+        /// Shift operator to <paramref name="operatorStack"/>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void Shift(Stack<(TKind, IExprDef<TKind>)> operatorStack, NextResult nextResult)
+        {
+            operatorStack.Push((nextResult.Token, nextResult.ExprDef));
+        }
+
+        /// <summary>
+        /// Figure out if we should shift or reduce, according to operators on stack
+        /// and last operator read.
+        /// </summary>
+        private ShiftReduce ShiftOrReduce(Stack<(TKind token, IExprDef<TKind> exprDef)> operatorStack,
+            IExprDef<TKind> exprDef)
+        {
+            if ( operatorStack.Count == 0 ) {
+                return ShiftReduce.Shift;
+            }
+
+            var top = operatorStack.Peek();
+
+            // Operator have same precedence. Left associative infix operators are reduced,
+            // all others are shifted
+            if ( top.exprDef.Precedence == exprDef.Precedence ) {
+                return ( top.exprDef as InfixOprDef<TKind, T, U> )?.Associativity == InfixOprAssociativity.Left ?
+                    ShiftReduce.Reduce : ShiftReduce.Shift;
+            }
+
+            return top.exprDef.Precedence > exprDef.Precedence ? ShiftReduce.Reduce : ShiftReduce.Shift;
+        }
+
+        /// <summary>
+        /// <para>
+        /// Read next value from input. Both the <paramref name="next"/> and
+        /// <paramref name="expectedNext"/> are updated to reflect that we have
+        /// consumed tokens from input.
+        /// </para>
+        /// <para>This method ensures, that all operators and operands put on the stack
+        /// indeed follow the grammar. This way, the main parse loop only need to handle
+        /// when to shift/reduce.</para>
+        /// </summary>
+        private NextResult ReadNext(
+            ref TokenListParserResult<TKind, Token<TKind>> next,
+            ref ExpectedNext expectedNext)
+        {
+
+            // We accept the following
+            // EXPR            ::= (OPERAND | SET) [INFIX-OPR EXPR]
+            //                   | PREFIX-OPR EXPR
+            //                   | IF EXPR THEN EXPR [ELSE EXPR]
+            // SET             ::= SET_START [EXPR (SET_SEPARATOR EXPR)*] SET_END
+            //
+            // There are two main cases to handle
+            // 1: We expect an operand. In this case
+            //    - Accept prefix operator
+            //    - Accept start of new set
+            //    - Accept IF in If-Then-Else
+            //    - Accept operand
+            //    - Do not accept end-of-input
+            //    - Do not accept THEN / ELSE in If-Then-Else
+            // 2: We do not expect operand. In this case
+            //    - Accept infix operator
+            //    - Accept separator in current set / end of current set
+            //    - Accept end-of-input (given there are no open sets or open IF)
+            //    - Accept THEN (given there is an open IF)
+            //    - Accept ELSE (given there is an open THEN)
+            //    - Do not accept prefix operator
+            //    - Do not accept start of new set
+            //    - Do not accept IF in If-Then-Else
+
+            return expectedNext.ExpectOperand ?
+                ReadNextOperand(ref next, ref expectedNext) :
+                ReadNextOperator(ref next, ref expectedNext);
+        }
+
+        private void PopExpected(Stack<(TKind token, IExprDef<TKind>)> stack, TKind expectedToken, string msg = null)
+        {
+            if ( stack.Count == 0 ) {
+                throw new InvalidOperationException($"Operator stack is empty, expected {expectedToken}. {msg}");
+            }
+
+            if ( !expectedToken.Equals(stack.Pop().token) ) {
+                throw new InvalidOperationException(
+                    $"Invalid token at top of operator stack, expecting {expectedToken}. {msg}");
+            }
+        }
+
+        private NextResult ReadNextOperand(
+            ref TokenListParserResult<TKind, Token<TKind>> next,
+            ref ExpectedNext expectedNext)
+        {
+
+            var token = next.HasValue ? next.Value.Kind : EmptyToken;
+
+            // Accept prefix operator
+            if ( next.HasValue &&
+                 _prefixOperators.TryGetValue(next.Value.Kind, out var prefixOprDef) ) {
+                next = next.Remainder.ConsumeToken();
+                return new NextResult(ResultType.Operator, token, prefixOprDef, EmptyParseResult);
+            }
+
+            // Accept start of new set
+            if ( next.HasValue &&
+                 _setDefinitions.TryGetValue(next.Value.Kind, out var setDef) &&
+                 setDef.SetStart.Equals(next.Value.Kind) ) {
+                next = next.Remainder.ConsumeToken();
+
+                // Check if set is empty
+                if ( next.HasValue && setDef.SetEnd.Equals(next.Value.Kind) && setDef.AllowEmptySet ) {
+                    expectedNext.ExpectOperand = false;
+                    next = next.Remainder.ConsumeToken();
+                    // Return of the empty token means that set is empty
+                    return new NextResult(ResultType.Set, EmptyToken, setDef, EmptyParseResult);
+                }
+
+                expectedNext.OpenSet.Push(setDef);
+
+                return new NextResult(ResultType.Set, token, setDef, EmptyParseResult);
+            }
+
+            // Accept IF
+            if ( next.HasValue &&
+                 _iteDefinitions.TryGetValue(next.Value.Kind, out var iteDef) &&
+                 iteDef.IfToken.Equals(next.Value.Kind) ) {
+                expectedNext.OpenIte.Push((iteDef.IfToken, iteDef));
+                next = next.Remainder.ConsumeToken();
+
+                return new NextResult(ResultType.IfThenElse, token, iteDef, EmptyParseResult);
+            }
+
+            // Accept operand
+            var operand = _operandParser(next.Location);
+            expectedNext.ExpectOperand = false;
+            next = operand.Remainder.ConsumeToken();
+
+            return new NextResult(operand.HasValue ? ResultType.Operand : ResultType.Error, EmptyToken, EmptyExprDef,
+                operand);
+        }
+
+        private NextResult ReadNextOperator(
+            ref TokenListParserResult<TKind, Token<TKind>> next,
+            ref ExpectedNext expectedNext)
+        {
+
+            var openSet = expectedNext.OpenSet.Count > 0 ? expectedNext.OpenSet.Peek() : null;
+            var openIte = expectedNext.OpenIte.Count > 0 ? expectedNext.OpenIte.Peek() : (EmptyToken, null);
+
+            var token = next.HasValue ? next.Value.Kind : EmptyToken;
+
+            // Accept infix operator
+            if ( next.HasValue &&
+                 _infixOperators.TryGetValue(next.Value.Kind, out var infixOprDef) ) {
+                next = next.Remainder.ConsumeToken();
+                expectedNext.ExpectOperand = true;
+
+                return new NextResult(ResultType.Operator, token, infixOprDef, EmptyParseResult);
+            }
+
+            // Accept separator / end of current open set
+            if ( next.HasValue &&
+                 openSet?.IsSeparatorOrEnd(token) == true ) {
+                next = next.Remainder.ConsumeToken();
+
+                if ( openSet.SetEnd.Equals(token) ) {
+                    expectedNext.OpenSet.Pop();
+                }
+                else {
+                    // After separator, there must be an operand
+                    expectedNext.ExpectOperand = true;
+                }
+
+                return new NextResult(ResultType.Set, token, openSet, EmptyParseResult);
+            }
+
+            // If we get THEN when another THEN is open, then we can close the open THEN
+            if ( next.HasValue &&
+                 openIte.iteDef?.ThenToken.Equals(token) == true &&
+                 openIte.iteDef.ThenToken.Equals(openIte.token) ) {
+                expectedNext.OpenIte.Pop();
+                openIte = expectedNext.OpenIte.Count > 0 ? expectedNext.OpenIte.Peek() : (EmptyToken, null);
+            }
+
+            // Accept THEN of current open IF
+            if ( next.HasValue &&
+                 openIte.iteDef?.ThenToken.Equals(token) == true &&
+                 openIte.iteDef.IfToken.Equals(openIte.token) ) {
+                next = next.Remainder.ConsumeToken();
+                expectedNext.ExpectOperand = true;
+                // Replace open IF with open THEN
+                expectedNext.OpenIte.Pop();
+                expectedNext.OpenIte.Push((openIte.iteDef.ThenToken, openIte.iteDef));
+                return new NextResult(ResultType.IfThenElse, token, openIte.iteDef, EmptyParseResult);
+            }
+
+            // Accept ELSE of current open IF-THEN
+            if ( next.HasValue &&
+                 openIte.iteDef?.ElseToken.Equals(token) == true &&
+                 openIte.iteDef.ThenToken.Equals(openIte.token) ) {
+                next = next.Remainder.ConsumeToken();
+                // Close matching open IF-THEN
+                if ( !openIte.iteDef.ThenToken.Equals(expectedNext.OpenIte.Pop().token) ) {
+                    throw new InvalidOperationException("ELSE did not have matching IF-THEN on ite stack");
+                }
+
+                expectedNext.ExpectOperand = true;
+                return new NextResult(ResultType.IfThenElse, token, openIte.iteDef, EmptyParseResult);
+            }
+
+            // Ensure we have closed all open sets
+            if ( openSet != null ) {
+                return new NextResult(ResultType.Error, EmptyToken, EmptyExprDef,
+                    TokenListParserResult.Empty<TKind, T>(next.Location,
+                        new[] { Presentation.FormatExpectation(openSet.SetEnd) }));
+            }
+
+            // Ensure we have closed all open IF (no missing THEN). Consider case where we have "IF IF x THEN" (outer IF not closed)
+            while ( expectedNext.OpenIte.Count > 0 ) {
+                openIte = expectedNext.OpenIte.Pop();
+                // If we have open IF, report missing THEN
+                if ( openIte.token.Equals(openIte.iteDef.IfToken) ) {
+                    return new NextResult(ResultType.Error, EmptyToken, EmptyExprDef,
+                        TokenListParserResult.Empty<TKind, T>(next.Location,
+                            new[] { Presentation.FormatExpectation(openIte.iteDef.ThenToken) }));
+                }
+            }
+
+            // All done
+            return new NextResult(ResultType.EndOfInput, EmptyToken, EmptyExprDef, EmptyParseResult);
+        }
+    }
+}

--- a/src/Superpower/OperatorPrecedenceParser/PrefixOprDef.cs
+++ b/src/Superpower/OperatorPrecedenceParser/PrefixOprDef.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Superpower.OperatorPrecedenceParser
+{
+    /// <summary>
+    /// Definition of group of unary prefix operators
+    /// </summary>
+    /// <typeparam name="TKind">Type of tokens parsed</typeparam>
+    /// <typeparam name="T">Type of result output by parser</typeparam>
+    /// <typeparam name="U">Type of binary operators which tokens are transformed into</typeparam>
+    internal class PrefixOprDef<TKind, T, U> : IExprOprDef<TKind>
+    {
+
+        /// <summary>
+        /// Create <see cref="PrefixOprDef{TKind,T,U}"/> representing a group of prefix
+        /// operators with same <see cref="Precedence"/>
+        /// </summary>
+        /// <param name="precedence">Operator precedence of all operators specified</param>
+        /// <param name="tokenToOperator">Function for transforming token of type <typeparamref name="TKind"/>
+        /// into unary operator of type <typeparamref name="U"/></param>
+        /// <param name="resultBuilder">Function for creating result of type <typeparamref name="T"/>
+        /// given an operator of type <typeparamref name="U"/> and one arguments of type
+        /// <typeparamref name="T"/></param>
+        /// <param name="tokens">Tokens representing operators in this operator group</param>
+        public PrefixOprDef(
+            int precedence,
+            Func<TKind, U> tokenToOperator,
+            Func<U, T, T> resultBuilder,
+            params TKind[] tokens)
+        {
+            Precedence = precedence;
+            Tokens = tokens;
+            TokenToOperator = tokenToOperator;
+            ResultBuilder = resultBuilder;
+
+            // Validate that token mapping works
+            foreach ( var token in tokens ) {
+                try {
+                    tokenToOperator(token);
+                }
+                catch {
+                    throw new InvalidDataException($"Token {token} is not mapped correctly");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Method for mapping an operand into a single operand using provided operator
+        /// </summary>
+        public Func<U, T, T> ResultBuilder { get; set; }
+
+        /// <summary>
+        /// Mapping from tokens in <see cref="Tokens"/> to operator of type <typeparamref name="U"/>
+        /// </summary>
+
+        public Func<TKind, U> TokenToOperator { get; set; }
+
+
+        /// <inheritdoc />
+        public IReadOnlyList<TKind> Tokens { get; set; }
+
+        /// <inheritdoc />
+        public int Precedence { get; }
+    }
+}

--- a/src/Superpower/Superpower.csproj
+++ b/src/Superpower/Superpower.csproj
@@ -33,6 +33,10 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+    
+  <ItemGroup>
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+  </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DefineConstants>$(DefineConstants);CHECKED</DefineConstants>

--- a/test/Superpower.Tests/BoolExpressionScenario/BoolExpressionParser.cs
+++ b/test/Superpower.Tests/BoolExpressionScenario/BoolExpressionParser.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Superpower.OperatorPrecedenceParser;
+using Superpower.Parsers;
+using Xunit.Sdk;
+
+namespace Superpower.Tests.BoolExpressionScenario
+{
+    class BoolExpressionParser
+    {
+        /// <summary>
+        /// Mapping from token representing operator to expression operator
+        /// </summary>
+        private static readonly Dictionary<BoolExpressionToken, ExpressionType> TokenToOprMap =
+            new Dictionary<BoolExpressionToken, ExpressionType> {
+                { BoolExpressionToken.Plus, ExpressionType.AddChecked },
+                { BoolExpressionToken.Minus, ExpressionType.SubtractChecked },
+                { BoolExpressionToken.Times, ExpressionType.Multiply },
+                { BoolExpressionToken.Divide, ExpressionType.Divide },
+                { BoolExpressionToken.Lt, ExpressionType.LessThan },
+                { BoolExpressionToken.Gt, ExpressionType.GreaterThan },
+                { BoolExpressionToken.And, ExpressionType.And },
+                { BoolExpressionToken.Or, ExpressionType.Or },
+                { BoolExpressionToken.Not, ExpressionType.Not },
+                { BoolExpressionToken.In, (ExpressionType)(-1) }
+            };
+
+        /// <summary>
+        /// Define a simple integer constant
+        /// </summary>
+        static readonly TokenListParser<BoolExpressionToken, Expression> Constant =
+            Token.EqualTo(BoolExpressionToken.Number)
+                .Apply(Numerics.IntegerInt32)
+                .Select(n => (Expression) Expression.Constant(n));
+
+        /// <summary>
+        /// The variable naming convention in the example is, that variables starting with 'b'
+        /// are Boolean variables, all other variables are integer variables (should start with 'i')
+        /// </summary>
+        private static readonly TokenListParser<BoolExpressionToken, Expression> Variable =
+            Token.EqualTo(BoolExpressionToken.Variable)
+                .Select(v => (Expression) Expression.Variable(
+                    v.ToStringValue()[0] == 'b' ? typeof( bool ) : typeof( Int32 ),
+                    v.ToStringValue()));
+
+        static readonly TokenListParser<BoolExpressionToken, Expression> ExprOperand =
+            Constant.Or(Variable);
+
+        /// <summary>
+        /// Method use to create a new list of expression
+        /// </summary>
+        private static readonly Func<IEnumerable<Expression>, IEnumerable<BoolExpressionToken>, Expression> _setBuilder
+            =
+            (args, seps) =>
+                Expression.ListInit(
+                    Expression.New(typeof( List<int> )),
+                    args.Select(e => Expression.ElementInit(typeof( List<int> ).GetMethod("Add"), e)));
+
+        /// <summary>
+        /// Representation of IN. "x in {1,2}" becomes List&lt;object&gt;(){1,2}.Contains(x)
+        /// </summary>
+        private static readonly Expression<Func<IEnumerable<int>, int, bool>> _inFunc =
+            (set, elem) => set.Contains(elem);
+
+        private static readonly Func<ExpressionType, Expression, Expression, Expression> x =
+            (opr, elem, set) => Expression.Invoke(_inFunc, set, elem);
+
+        private static readonly IExprDef<BoolExpressionToken>[] ExprDefs = {
+            // OR
+            new InfixOprDef<BoolExpressionToken, Expression, ExpressionType>(
+                1, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
+                BoolExpressionToken.Or),
+            // AND
+            new InfixOprDef<BoolExpressionToken, Expression, ExpressionType>(
+                2, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
+                BoolExpressionToken.And),
+            // LT, GT
+            new InfixOprDef<BoolExpressionToken, Expression, ExpressionType>(
+                3, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
+                BoolExpressionToken.Lt, BoolExpressionToken.Gt),
+            // PLUS, MINUS
+            new InfixOprDef<BoolExpressionToken, Expression, ExpressionType>(
+                4, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
+                BoolExpressionToken.Plus, BoolExpressionToken.Minus),
+            // TIMES, DIVIDE
+            new InfixOprDef<BoolExpressionToken, Expression, ExpressionType>(
+                5, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
+                BoolExpressionToken.Times, BoolExpressionToken.Divide),
+            // UNARY NOT, UNARY MINUS
+            new PrefixOprDef<BoolExpressionToken,Expression,ExpressionType>(
+                6, t => TokenToOprMap[t], (oprType, expr)=>Expression.MakeUnary(oprType,expr,null),
+                BoolExpressionToken.Not, BoolExpressionToken.Minus),
+            // IN
+            new InfixOprDef<BoolExpressionToken, Expression, ExpressionType>(
+                7, InfixOprAssociativity.Left, t => TokenToOprMap[t], x,
+                BoolExpressionToken.In),
+            // Parenthesis ( EXPR )
+            new ExprSetDef<BoolExpressionToken,Expression>(
+                BoolExpressionToken.LParen, BoolExpressionToken.RParen ),
+            // Set (lists) of expressions { e1, e2, e3 }
+            new ExprSetDef<BoolExpressionToken,Expression>(
+                BoolExpressionToken.LCrl, BoolExpressionToken.RCrl, new [] {BoolExpressionToken.Comma},
+                true, _setBuilder ),
+            // IF-x-THEN-y-ELSE-z ==  x ? y : z
+            // IF-x-THEN-y        == x -> y == not x or y (imply operator)
+            new IfThenElseDef<BoolExpressionToken,Expression>(
+                BoolExpressionToken.If, BoolExpressionToken.Then, BoolExpressionToken.Else,
+                Expression.Condition, (c,t) => Expression.Or(Expression.Not(c), t) )
+        };
+
+        public static readonly TokenListParser<BoolExpressionToken, Expression> Expr =
+            OperatorPrecedenceParser<BoolExpressionToken, Expression, ExpressionType>.DefineParser(
+                ExprDefs, ExprOperand).AtEnd();
+    }
+}

--- a/test/Superpower.Tests/BoolExpressionScenario/BoolExpressionScenarioTests.cs
+++ b/test/Superpower.Tests/BoolExpressionScenario/BoolExpressionScenarioTests.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Superpower.Tests.Support;
+using Xunit;
+
+namespace Superpower.Tests.BoolExpressionScenario
+{
+    public class BoolExpressionScenarioTests
+    {
+        [Theory]
+        [InlineData("1 + 2 * 2 > 0", "((1 + (2 * 2)) > 0)")]
+        [InlineData("3 * 2 / 1 < 4 / 3 + 1", "(((3 * 2) / 1) < ((4 / 3) + 1))")]
+        [InlineData("3 * i1 / i2 > i3", "(((3 * i1) / i2) > i3)")]
+        [InlineData("i1 + i2 + i3 + i4 + i5 > 0 ", "(((((i1 + i2) + i3) + i4) + i5) > 0)")]
+        [InlineData("b1 & !b2 & b3", "((b1 And Not(b2)) And b3)")]
+        [InlineData( "!b1 | !b2 & !b3", "(Not(b1) Or (Not(b2) And Not(b3)))" )]
+        [InlineData( "!(b1 | !b2)", "Not((b1 Or Not(b2)))" )]
+        [InlineData( "!!b1", "Not(Not(b1))" )]
+        public void EnsureExpectedOperatorPrecedence(string exprString, string expected)
+        {
+            var tokenizer = new BoolExpressionTokenizer();
+            var expression = BoolExpressionParser.Expr(tokenizer.Tokenize(exprString));
+            Assert.True(expression.HasValue);
+            Assert.Equal(expected, expression.Value.ToString());
+        }
+
+        [Theory]
+        [InlineData( "if i1 + i2 > i3 then b1 else b2", "IIF(((i1 + i2) > i3), b1, b2)" )]
+        [InlineData( "if if b1 then b2 else b3 then b4 else b5", "IIF(IIF(b1, b2, b3), b4, b5)" )]
+        [InlineData( "if if b1 then b2 else b3 then b4", "(Not(IIF(b1, b2, b3)) Or b4)" )]
+        [InlineData( "if b1 then b2", "(Not(b1) Or b2)" )]
+        public void IfThenElseConstructs( string exprString, string expected )
+        {
+            var tokenizer = new BoolExpressionTokenizer();
+            var expression = BoolExpressionParser.Expr( tokenizer.Tokenize( exprString ) );
+            Assert.True( expression.HasValue );
+            Assert.Equal( expected, expression.Value.ToString() );
+        }
+
+        [Theory]
+        [InlineData("if b1", "Syntax error: unexpected end of input, expected `then`." )]
+        [InlineData( "if b1 then then", "Syntax error (line 1, column 12): unexpected keyword `then`, expected number or variable." )]
+        [InlineData( "if b1 then else", "Syntax error (line 1, column 12): unexpected keyword `else`, expected number or variable." )]
+        [InlineData( "b1 then b2", "Syntax error (line 1, column 4): unexpected keyword `then`." )]
+        public void IfThenElseConstructsErrors( string exprString, string expectedMessage)
+        {
+            var tokenizer = new BoolExpressionTokenizer();
+            var result = BoolExpressionParser.Expr.TryParse( tokenizer.Tokenize( exprString ) );
+            var resultMsg = result.ToString();
+
+            Assert.False( result.HasValue);
+            Assert.Equal( expectedMessage, resultMsg );
+        }
+
+        [Theory]
+        [InlineData( "i1 in {1,2}", "Invoke((set, elem) => set.Contains(elem), new List`1() {Void Add(Int32)(1), Void Add(Int32)(2)}, i1)" )]
+        public void Collections( string exprString, string expected ) {
+
+            Func<IEnumerable<Expression>,IEnumerable<BoolExpressionToken>,Expression> resultBuilder = (args, seps) =>
+                Expression.ListInit(
+                    Expression.New(typeof( List<Expression> )),
+                    args );
+
+            var tokenizer = new BoolExpressionTokenizer();
+            var expression = BoolExpressionParser.Expr( tokenizer.Tokenize( exprString ) );
+            Assert.True( expression.HasValue );
+            Assert.Equal( expected, expression.Value.ToString() );
+        }
+    }
+}

--- a/test/Superpower.Tests/BoolExpressionScenario/BoolExpressionToken.cs
+++ b/test/Superpower.Tests/BoolExpressionScenario/BoolExpressionToken.cs
@@ -1,0 +1,68 @@
+﻿using Superpower.Display;
+
+namespace Superpower.Tests.BoolExpressionScenario
+{
+    public enum BoolExpressionToken
+    {
+        None,
+
+        Number,
+
+        Variable,
+
+        [Token(Category = "operator", Example = "+")]
+        Plus,
+
+        [Token(Category = "operator", Example = "-")]
+        Minus,
+
+        [Token(Category = "operator", Example = "*")]
+        Times,
+
+        [Token(Category = "operator", Example = "-")]
+        Divide,
+
+        [Token( Category = "operator", Example = "<" )]
+        Lt,
+
+        [Token( Category = "operator", Example = ">" )]
+        Gt,
+
+        [Token( Category = "operator", Example = "&" )]
+        And,
+
+        [Token( Category = "operator", Example = "|" )]
+        Or,
+
+        [Token( Category = "operator", Example = "!" )]
+        Not,
+
+        [Token( Category = "keyword", Example = "if" )]
+        If,
+
+        [Token( Category = "keyword", Example = "then" )]
+        Then,
+
+
+        [Token( Category = "keyword", Example = "else" )]
+        Else,
+
+        [Token( Category = "keyword", Example = "in" )]
+        In,
+
+        [Token(Example = "(")]
+        LParen,
+
+        [Token(Example = ")")]
+        RParen,
+
+        [Token( Example = "{" )]
+        LCrl,
+
+        [Token( Example = "}" )]
+        RCrl,
+
+        [Token( Example = "," )]
+        Comma
+    }
+}

--- a/test/Superpower.Tests/BoolExpressionScenario/BoolExpressionTokenizer.cs
+++ b/test/Superpower.Tests/BoolExpressionScenario/BoolExpressionTokenizer.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using Superpower.Model;
+using Superpower.Parsers;
+
+namespace Superpower.Tests.BoolExpressionScenario
+{
+    class BoolExpressionTokenizer : Tokenizer<BoolExpressionToken>
+    {
+        private readonly Dictionary<char, BoolExpressionToken> _operators = new Dictionary<char, BoolExpressionToken> {
+            ['+'] = BoolExpressionToken.Plus,
+            ['-'] = BoolExpressionToken.Minus,
+            ['*'] = BoolExpressionToken.Times,
+            ['/'] = BoolExpressionToken.Divide,
+            ['('] = BoolExpressionToken.LParen,
+            [')'] = BoolExpressionToken.RParen,
+            ['{'] = BoolExpressionToken.LCrl,
+            ['}'] = BoolExpressionToken.RCrl,
+            [','] = BoolExpressionToken.Comma,
+            ['&'] = BoolExpressionToken.And,
+            ['|'] = BoolExpressionToken.Or,
+            ['>'] = BoolExpressionToken.Gt,
+            ['<'] = BoolExpressionToken.Lt,
+            ['!'] = BoolExpressionToken.Not
+        };
+
+        private readonly Dictionary<string, BoolExpressionToken> _keywords = new Dictionary<string, BoolExpressionToken> {
+            ["if"] = BoolExpressionToken.If,
+            ["then"] = BoolExpressionToken.Then,
+            ["else"] = BoolExpressionToken.Else,
+            ["in"] = BoolExpressionToken.In
+        };
+
+        protected override IEnumerable<Result<BoolExpressionToken>> Tokenize(TextSpan span)
+        {
+            var next = SkipWhiteSpace(span);
+            if (!next.HasValue)
+                yield break;
+
+            do
+            {
+                BoolExpressionToken charToken;
+
+                if (char.IsDigit(next.Value))
+                {
+                    var integer = Numerics.Integer(next.Location);
+                    next = integer.Remainder.ConsumeChar();
+                    yield return Result.Value(BoolExpressionToken.Number, integer.Location, integer.Remainder);
+                }
+                else if (char.IsLetter(next.Value)) {
+                    var start = next.Location;
+                    while ( next.HasValue && char.IsLetterOrDigit(next.Value) ) {
+                        next = next.Remainder.ConsumeChar();
+                    }
+
+                    var str = next.Location.Source.Substring(
+                        start.Position.Absolute,
+                        next.Location.Position.Absolute - start.Position.Absolute);
+
+                    yield return _keywords.TryGetValue(str, out var token) ?
+                        Result.Value(token, start, next.Location) :
+                        Result.Value(BoolExpressionToken.Variable, start, next.Location);
+                }
+                else if (_operators.TryGetValue(next.Value, out charToken)) {
+                    yield return Result.Value(charToken, next.Location, next.Remainder);
+                    next = next.Remainder.ConsumeChar();
+                }
+                else {
+                    yield return Result.Empty<BoolExpressionToken>(next.Location, new[] { "number", "variable", "operator" });
+                }
+
+                next = SkipWhiteSpace(next.Location);
+            } while (next.HasValue);
+        }
+    }
+}


### PR DESCRIPTION
Porting a parser from [FParsec](http://www.quanttec.com/fparsec/), I was missing a convenient way to declare in-fix and pre-fix operators in a declarative way, which would handle both operator associativity and operator precedence.

This pull request contains some new classes, allowing a user to define simple expressions in a declarative way, and build a parser from these declarations. Expressions that can be expressed are of the simple form

```
EXPR  ::= EXPR infixOpr EXPR
        | prefixOpr EXPR
		| SET
		| if EXPR then EXPR [else EXPR]
SET   ::= setStart [EXPR (separator EXPR)*] setEnd
```

My first attempt was to implement this using parser combinators. Unfortunately, running tests on this, I quickly ran into stack overflow exception, when parsing deeply nested expression (not surprisingly). 

Looking at the grammar above, I observe the following properties: 
* No production token accept the empty string
* No production token contains to consecutive non-terminal symbols

As such, the grammar supported can be implemented using a simple (but highly efficient) [operator precedence parser](https://en.wikipedia.org/wiki/Operator-precedence_parser).

This pull request contains a way for declaratively defining grammars for expressions. An example for Boolean expressions is checked in. The declaration looks like this:

``` C#
        private static readonly IExprDef<BoolExpressionToken>[] ExprDefs = {
            // OR
            new InfixOprDef<BoolExpressionToken, Expression, ExpressionType>(
                1, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
                BoolExpressionToken.Or),
            // AND
            new InfixOprDef<BoolExpressionToken, Expression, ExpressionType>(
                2, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
                BoolExpressionToken.And),
            // LT, GT
            new InfixOprDef<BoolExpressionToken, Expression, ExpressionType>(
                3, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
                BoolExpressionToken.Lt, BoolExpressionToken.Gt),
            // PLUS, MINUS
            new InfixOprDef<BoolExpressionToken, Expression, ExpressionType>(
                4, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
                BoolExpressionToken.Plus, BoolExpressionToken.Minus),
            // TIMES, DIVIDE
            new InfixOprDef<BoolExpressionToken, Expression, ExpressionType>(
                5, InfixOprAssociativity.Left, t => TokenToOprMap[t], Expression.MakeBinary,
                BoolExpressionToken.Times, BoolExpressionToken.Divide),
            // UNARY NOT, UNARY MINUS
            new PrefixOprDef<BoolExpressionToken,Expression,ExpressionType>(
                6, t => TokenToOprMap[t], (oprType, expr)=>Expression.MakeUnary(oprType,expr,null),
                BoolExpressionToken.Not, BoolExpressionToken.Minus),
            // IN
            new InfixOprDef<BoolExpressionToken, Expression, ExpressionType>(
                7, InfixOprAssociativity.Left, t => TokenToOprMap[t], x,
                BoolExpressionToken.In),
            // Parenthesis ( EXPR )
            new ExprSetDef<BoolExpressionToken,Expression>(
                BoolExpressionToken.LParen, BoolExpressionToken.RParen ),
            // Set (lists) of expressions { e1, e2, e3 }
            new ExprSetDef<BoolExpressionToken,Expression>(
                BoolExpressionToken.LCrl, BoolExpressionToken.RCrl, new [] {BoolExpressionToken.Comma},
                true, _setBuilder ),
            // IF-x-THEN-y-ELSE-z ==  x ? y : z
            // IF-x-THEN-y        == x -> y == not x or y (imply operator)
            new IfThenElseDef<BoolExpressionToken,Expression>(
                BoolExpressionToken.If, BoolExpressionToken.Then, BoolExpressionToken.Else,
                Expression.Condition, (c,t) => Expression.Or(Expression.Not(c), t) )
        };

        public static readonly TokenListParser<BoolExpressionToken, Expression> Expr =
            OperatorPrecedenceParser<BoolExpressionToken, Expression, ExpressionType>.DefineParser(
                ExprDefs, ExprOperand).AtEnd();
```
I've tested the code against a large set of expressions (it's used in a replacement for an existing FParsec parser), and have found the approach to perform extremely well (the generated parser is extremely fast).

This extension has made my resulting Superpower parser much easier to read/write. I hope this can be of usage to other people when building parsers for simple expressions.

Note: a good article showing a simple implementation of this can be found [here](http://epaperpress.com/oper/download/OperatorPrecedenceParsing.pdf)