### PR TITLE
Initial round of v2 changes

### DIFF
--- a/src/Superpower/Model/TextSpan.cs
+++ b/src/Superpower/Model/TextSpan.cs
@@ -170,7 +170,7 @@ namespace Superpower.Model
             next.EnsureHasValue();
             if (next.Source != Source) throw new ArgumentException("The spans are on different source strings.", nameof(next));
 #endif
-                var charCount = Length - next.Length;
+            var charCount = Length - next.Length;
             return First(charCount);
         }
 
@@ -187,6 +187,28 @@ namespace Superpower.Model
 #endif
 
             return new TextSpan(Source, Position, length);
+        }
+        
+        /// <summary>
+        /// Skip a specified number of characters. Note, this is an O(N) operation.
+        /// </summary>
+        /// <param name="count"></param>
+        public TextSpan Skip(int count)
+        {
+            EnsureHasValue();
+            
+#if CHECKED
+            if (count > Length)
+                throw new ArgumentOutOfRangeException(nameof(count), "Count exceeds the source span's length.");
+#endif
+
+            var p = Position;
+            for (var i = 0; i < count; ++i)
+            {
+                p = p.Advance(Source[p.Absolute]);
+            }
+
+            return new TextSpan(Source, p, Length - count);
         }
 
         /// <inheritdoc/>

--- a/src/Superpower/Model/TextSpan.cs
+++ b/src/Superpower/Model/TextSpan.cs
@@ -190,7 +190,7 @@ namespace Superpower.Model
         }
         
         /// <summary>
-        /// Skip a specified number of characters. Note, this is an O(N) operation.
+        /// Skip a specified number of characters. Note, this is an O(count) operation.
         /// </summary>
         /// <param name="count"></param>
         public TextSpan Skip(int count)

--- a/src/Superpower/Model/TokenizationState.cs
+++ b/src/Superpower/Model/TokenizationState.cs
@@ -1,0 +1,28 @@
+// Copyright 2018 Datalust, Superpower Contributors, Sprache Contributors
+//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  
+//
+//     http://www.apache.org/licenses/LICENSE-2.0  
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Superpower.Model
+{
+    /// <summary>
+    /// Represents the progress of a single tokenization operation.
+    /// </summary>
+    /// <typeparam name="TKind">The kind of token being produced.</typeparam>
+    public class TokenizationState<TKind>
+    {
+        /// <summary>
+        /// The last produced token.
+        /// </summary>
+        public Token<TKind>? Previous { get; set; }
+    }
+}

--- a/src/Superpower/Parse.cs
+++ b/src/Superpower/Parse.cs
@@ -42,27 +42,25 @@ namespace Superpower
             if (operand == null) throw new ArgumentNullException(nameof(operand));
             if (apply == null) throw new ArgumentNullException(nameof(apply));
 
-            return input => {
+            return input =>
+            {
                 var parseResult = operand(input);
-                if (!parseResult.HasValue) {
+                if (!parseResult.HasValue)
                     return parseResult;
-                }
 
                 var result = parseResult.Value;
 
                 var operatorResult = @operator(parseResult.Remainder);
-                while (operatorResult.HasValue || operatorResult.IsPartial(parseResult.Remainder)) {
+                while (operatorResult.HasValue || operatorResult.IsPartial(parseResult.Remainder))
+                {
                     // If operator read any input, but failed to read complete input, we return error
-                    if (!operatorResult.HasValue) {
+                    if (!operatorResult.HasValue)
                         return Result.CastEmpty<TOperator,T>(operatorResult);
-                    }
-
 
                     parseResult = operand(operatorResult.Remainder);
 
-                    if (!parseResult.HasValue) {
+                    if (!parseResult.HasValue)
                         return parseResult;
-                    }
 
                     result = apply(operatorResult.Value, result, parseResult.Value);
                     operatorResult = @operator(parseResult.Remainder);
@@ -129,24 +127,22 @@ namespace Superpower
             return input =>
             {
                 var parseResult = operand(input);
-                if ( !parseResult.HasValue ) {
+                if ( !parseResult.HasValue )
                     return parseResult;
-                }
 
                 var result = parseResult.Value;
 
                 var operatorResult = @operator(parseResult.Remainder);
-                while (operatorResult.HasValue || operatorResult.IsPartial(parseResult.Remainder)) {
+                while (operatorResult.HasValue || operatorResult.IsPartial(parseResult.Remainder))
+                {
                     // If operator read any input, but failed to read complete input, we return error
-                    if (!operatorResult.HasValue) {
+                    if (!operatorResult.HasValue) 
                         return TokenListParserResult.CastEmpty<TKind, TOperator, T>(operatorResult);
-                    }
 
                     parseResult = operand(operatorResult.Remainder);
 
-                    if (!parseResult.HasValue) {
+                    if (!parseResult.HasValue)
                         return TokenListParserResult.CastEmpty<TKind, T, T>(parseResult);
-                    }
 
                     result = apply(operatorResult.Value, result, parseResult.Value);
                     operatorResult = @operator(parseResult.Remainder);
@@ -191,6 +187,7 @@ namespace Superpower
                     ChainRightOperatorRest(operandValue, @operator, operand, apply)).Then(r => Return<TKind, T>(apply(opvalue, lastOperand, r))))
                     .Or(Return<TKind, T>(lastOperand));
         }
+        
         /// <summary>
         /// Constructs a parser that will fail if the given parser succeeds,
         /// and will succeed if the given parser fails. In any case, it won't

--- a/src/Superpower/ParserExtensions.cs
+++ b/src/Superpower/ParserExtensions.cs
@@ -108,7 +108,7 @@ namespace Superpower
         /// <param name="input">The input.</param>
         /// <returns>True if the parser is a complete match for the input; otherwise, false.</returns>
         /// <exception cref="ArgumentNullException">The parser is null.</exception>
-        /// <exception cref="ArgumentException">The input is <see cref="TextSpan.Empty"/>empty.</exception>
+        /// <exception cref="ArgumentException">The input is <see cref="TextSpan.Empty"/>.</exception>
         public static bool IsMatch<T>(this TextParser<T> parser, TextSpan input)
         {
             if (parser == null) throw new ArgumentNullException(nameof(parser));

--- a/src/Superpower/ParserExtensions.cs
+++ b/src/Superpower/ParserExtensions.cs
@@ -29,6 +29,7 @@ namespace Superpower
         /// <param name="parser">The parser.</param>
         /// <param name="input">The input.</param>
         /// <returns>The result of the parser</returns>
+        /// <exception cref="ArgumentNullException">The parser or input is null.</exception>
         public static Result<T> TryParse<T>(this TextParser<T> parser, string input)
         {
             if (parser == null) throw new ArgumentNullException(nameof(parser));
@@ -45,6 +46,7 @@ namespace Superpower
         /// <param name="parser">The parser.</param>
         /// <param name="input">The input.</param>
         /// <returns>The result of the parser</returns>
+        /// <exception cref="ArgumentNullException">The parser or input is null.</exception>
         public static TokenListParserResult<TKind, T> TryParse<TKind, T>(this TokenListParser<TKind, T> parser, TokenList<TKind> input)
         {
             if (parser == null) throw new ArgumentNullException(nameof(parser));
@@ -60,6 +62,7 @@ namespace Superpower
         /// <param name="parser">The parser.</param>
         /// <param name="input">The input.</param>
         /// <returns>The result of the parser.</returns>
+        /// <exception cref="ArgumentNullException">The parser or input is null.</exception>
         /// <exception cref="ParseException">It contains the details of the parsing error.</exception>
         public static T Parse<T>(this TextParser<T> parser, string input)
         {
@@ -82,6 +85,7 @@ namespace Superpower
         /// <param name="parser">The parser.</param>
         /// <param name="input">The input.</param>
         /// <returns>The result of the parser.</returns>
+        /// <exception cref="ArgumentNullException">The parser or input is null.</exception>
         /// <exception cref="ParseException">It contains the details of the parsing error.</exception>
         public static T Parse<TKind, T>(this TokenListParser<TKind, T> parser, TokenList<TKind> input)
         {
@@ -94,6 +98,24 @@ namespace Superpower
                 return result.Value;
 
             throw new ParseException(result.ToString());
+        }
+
+        /// <summary>
+        /// Tests whether the parser matches the entire provided <see cref="TextSpan"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the parser's result.</typeparam>
+        /// <param name="parser">The parser.</param>
+        /// <param name="input">The input.</param>
+        /// <returns>True if the parser is a complete match for the input; otherwise, false.</returns>
+        /// <exception cref="ArgumentNullException">The parser is null.</exception>
+        /// <exception cref="ArgumentException">The input is <see cref="TextSpan.Empty"/>empty.</exception>
+        public static bool IsMatch<T>(this TextParser<T> parser, TextSpan input)
+        {
+            if (parser == null) throw new ArgumentNullException(nameof(parser));
+            if (input == TextSpan.Empty) throw new ArgumentException("Input text span is empty.", nameof(input));
+
+            var result = parser(input);
+            return result.HasValue && result.Remainder.IsAtEnd;
         }
     }
 }

--- a/src/Superpower/Parsers/Comment.cs
+++ b/src/Superpower/Parsers/Comment.cs
@@ -1,0 +1,103 @@
+﻿// Copyright 2016 Datalust, Superpower Contributors, Sprache Contributors
+//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  
+//
+//     http://www.apache.org/licenses/LICENSE-2.0  
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Superpower.Model;
+
+namespace Superpower.Parsers
+{
+    /// <summary>
+    /// Parsers for matching comments in various styles
+    /// </summary>
+    public static class Comment
+    {
+        /// <summary>
+        /// Parses a comment that begins with a specified pattern and continues to the end of the line.
+        /// </summary>
+        /// <remarks>
+        /// The comment span does not include the end-of-line characters that terminate it.
+        /// </remarks>
+        /// <param name="beginComment">Recognizes the beginning of the comment.</param>
+        /// <returns>The span covered by the comment.</returns>
+        public static TextParser<TextSpan> ToEndOfLine(TextParser<TextSpan> beginComment)
+        {            
+            return i =>
+            {
+                var begin = beginComment(i);
+                if (!begin.HasValue)
+                    return begin;
+
+                var remainder = begin.Remainder;
+                while (!remainder.IsAtEnd)
+                {
+                    var ch = remainder.ConsumeChar();
+                    if (ch.Value == '\r' || ch.Value == '\n')
+                        break;
+
+                    remainder = ch.Remainder;
+                }
+
+                return Result.Value(i.Until(remainder), i, remainder);
+            };
+        }
+        
+        /// <summary>
+        /// Parses a C++ style comment, beginning with a double forward slash `//`
+        /// and continuing to the end of the line.
+        /// </summary>
+        public static TextParser<TextSpan> CPlusPlusStyle { get; } = ToEndOfLine(Span.EqualTo("//"));
+        
+        /// <summary>
+        /// Parses a SQL style comment, beginning with a double dash `--`
+        /// and continuing to the end of the line.
+        /// </summary>
+        public static TextParser<TextSpan> SqlStyle { get; } = ToEndOfLine(Span.EqualTo("--"));
+        
+        /// <summary>
+        /// Parses a shell style comment, beginning with a pound/hash `#` sign
+        /// and continuing to the end of the line.
+        /// </summary>
+        public static TextParser<TextSpan> ShellStyle { get; } = ToEndOfLine(Span.EqualTo("#"));
+
+        /// <summary>
+        /// Parses a C-style multiline comment beginning with `/*` and ending with `*/`.
+        /// </summary>
+        public static TextParser<TextSpan> CStyle
+        {
+            get
+            {
+                var beginComment = Span.EqualTo("/*");
+                var endComment = Span.EqualTo("*/");
+                return i =>
+                {
+                    var begin = beginComment(i);
+                    if (!begin.HasValue)
+                        return begin;
+
+                    var content = begin.Remainder;
+                    while (!content.IsAtEnd)
+                    {
+                        var end = endComment(content);
+                        if (end.HasValue)
+                            return Result.Value(i.Until(end.Remainder), i, end.Remainder);
+                            
+                        content = content.ConsumeChar().Remainder;
+                    }
+
+                    return endComment(content); // Will fail, because we're at the end-of-input.
+                };
+
+            }
+        }
+    }
+}

--- a/src/Superpower/Parsers/Comment.cs
+++ b/src/Superpower/Parsers/Comment.cs
@@ -17,7 +17,7 @@ using Superpower.Model;
 namespace Superpower.Parsers
 {
     /// <summary>
-    /// Parsers for matching comments in various styles
+    /// Parsers for matching comments in various styles.
     /// </summary>
     public static class Comment
     {

--- a/src/Superpower/Parsers/Numerics.cs
+++ b/src/Superpower/Parsers/Numerics.cs
@@ -19,14 +19,17 @@ namespace Superpower.Parsers
     /// <summary>
     /// Parsers for numeric patterns.
     /// </summary>
+    //* Fairly large amount of duplication/repetition here, due to the lack
+    //* of generics over numbers in C#.
     public static class Numerics
     {
         static readonly string[] ExpectedDigit = { "digit" };
+        static readonly string[] ExpectedSignOrDigit = { "sign", "digit" };
 
         /// <summary>
         /// A string of digits.
         /// </summary>
-        public static TextParser<TextSpan> Integer { get; } = input =>
+        public static TextParser<TextSpan> Natural { get; } = input =>
         {
             var next = input.ConsumeChar();
             if (!next.HasValue || !char.IsDigit(next.Value))
@@ -43,11 +46,97 @@ namespace Superpower.Parsers
         };
 
         /// <summary>
-        /// A string of digits, converted into an <see cref="int"/>.
+        /// A string of digits, converted into a <see cref="uint"/>.
+        /// </summary>
+        public static TextParser<uint> NaturalUInt32 { get; } = input =>
+        {
+            var next = input.ConsumeChar();
+            
+            if (!next.HasValue || !char.IsDigit(next.Value))
+                return Result.Empty<uint>(input, ExpectedDigit);
+
+            TextSpan remainder;
+            var val = 0u;
+            do
+            {
+                val = 10 * val + (uint)(next.Value - '0');
+                remainder = next.Remainder;
+                next = remainder.ConsumeChar();
+            } while (next.HasValue && char.IsDigit(next.Value));
+            
+            return Result.Value(val, input, remainder);
+        };
+
+        /// <summary>
+        /// A string of digits, converted into a <see cref="ulong"/>.
+        /// </summary>
+        public static TextParser<ulong> NaturalUInt64 { get; } = input =>
+        {
+            var next = input.ConsumeChar();
+            
+            if (!next.HasValue || !char.IsDigit(next.Value))
+                return Result.Empty<ulong>(input, ExpectedDigit);
+
+            TextSpan remainder;
+            var val = 0ul;
+            do
+            {
+                val = 10 * val + (ulong)(next.Value - '0');
+                remainder = next.Remainder;
+                next = remainder.ConsumeChar();
+            } while (next.HasValue && char.IsDigit(next.Value));
+            
+            return Result.Value(val, input, remainder);
+        };
+
+        /// <summary>
+        /// A string of digits with an optional +/- sign.
+        /// </summary>
+        public static TextParser<TextSpan> Integer { get; } = input =>
+        {
+            var next = input.ConsumeChar();
+            
+            if (!next.HasValue)
+                return Result.Empty<TextSpan>(input, ExpectedSignOrDigit);
+            
+            if (next.Value == '-' || next.Value == '+')
+                next = next.Remainder.ConsumeChar();
+
+            if (!next.HasValue || !char.IsDigit(next.Value))
+                return Result.Empty<TextSpan>(input, ExpectedDigit);
+
+            TextSpan remainder;
+            do
+            {
+                remainder = next.Remainder;
+                next = remainder.ConsumeChar();
+            } while (next.HasValue && char.IsDigit(next.Value));
+
+            return Result.Value(input.Until(remainder), input, remainder);
+        };
+
+        /// <summary>
+        /// A string of digits with an optional +/- sign, converted into an <see cref="int"/>.
         /// </summary>
         public static TextParser<int> IntegerInt32 { get; } = input =>
         {
+            var negative = false;
+            
             var next = input.ConsumeChar();
+
+            if (!next.HasValue)
+                return Result.Empty<int>(input, ExpectedSignOrDigit);
+            
+            if (next.Value == '-')
+            {
+                negative = true;
+                next = next.Remainder.ConsumeChar();
+            }
+            else if (next.Value == '+')
+            {
+                next = next.Remainder.ConsumeChar();
+            }
+            
             if (!next.HasValue || !char.IsDigit(next.Value))
                 return Result.Empty<int>(input, ExpectedDigit);
 
@@ -60,6 +149,49 @@ namespace Superpower.Parsers
                 next = remainder.ConsumeChar();
             } while (next.HasValue && char.IsDigit(next.Value));
 
+            if (negative)
+                val = -val;
+            
+            return Result.Value(val, input, remainder);
+        };
+
+        /// <summary>
+        /// A string of digits with an optional +/- sign, converted into an <see cref="long"/>.
+        /// </summary>
+        public static TextParser<long> IntegerInt64 { get; } = input =>
+        {
+            var negative = false;
+            
+            var next = input.ConsumeChar();
+
+            if (!next.HasValue)
+                return Result.Empty<long>(input, ExpectedSignOrDigit);
+            
+            if (next.Value == '-')
+            {
+                negative = true;
+                next = next.Remainder.ConsumeChar();
+            }
+            else if (next.Value == '+')
+            {
+                next = next.Remainder.ConsumeChar();
+            }
+            
+            if (!next.HasValue || !char.IsDigit(next.Value))
+                return Result.Empty<long>(input, ExpectedDigit);
+
+            TextSpan remainder;
+            var val = 0L;
+            do
+            {
+                val = 10 * val + (next.Value - '0');
+                remainder = next.Remainder;
+                next = remainder.ConsumeChar();
+            } while (next.HasValue && char.IsDigit(next.Value));
+
+            if (negative)
+                val = -val;
+            
             return Result.Value(val, input, remainder);
         };
     }

--- a/src/Superpower/Parsers/Span.cs
+++ b/src/Superpower/Parsers/Span.cs
@@ -153,11 +153,11 @@ namespace Superpower.Parsers
         /// </summary>
         /// <param name="predicate">A predicate.</param>
         /// <returns>The matched text.</returns>
-        public static TextParser<TextSpan> Until(Func<char, bool> predicate)
+        public static TextParser<TextSpan> WithoutAny(Func<char, bool> predicate)
         {
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
-            return While(ch => !predicate(ch));
+            return WithAll(ch => !predicate(ch));
         }
 
 
@@ -166,7 +166,7 @@ namespace Superpower.Parsers
         /// </summary>
         /// <param name="predicate">A predicate.</param>
         /// <returns>The matched text.</returns>
-        public static TextParser<TextSpan> While(Func<char, bool> predicate)
+        public static TextParser<TextSpan> WithAll(Func<char, bool> predicate)
         {
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
@@ -177,8 +177,10 @@ namespace Superpower.Parsers
                 {
                     next = next.Remainder.ConsumeChar();
                 }
-
-                return Result.Value(input.Until(next.Location), input, next.Location);
+                
+                return  next.Location == input ?
+                    Result.Empty<TextSpan>(input) :
+                    Result.Value(input.Until(next.Location), input, next.Location);
             };
         }
 
@@ -193,7 +195,9 @@ namespace Superpower.Parsers
                 next = next.Remainder.ConsumeChar();
             }
 
-            return Result.Value(input.Until(next.Location), input, next.Location);
+            return next.Location == input ?
+                Result.Empty<TextSpan>(input) :
+                Result.Value(input.Until(next.Location), input, next.Location);
         };
     }
 }

--- a/src/Superpower/Parsers/Span.cs
+++ b/src/Superpower/Parsers/Span.cs
@@ -22,7 +22,7 @@ namespace Superpower.Parsers
     /// <summary>
     /// Parsers for spans of characters.
     /// </summary>
-    public class Span
+    public static class Span
     {
         /// <summary>
         /// Parse a span of length <paramref name="length"/>/>.

--- a/src/Superpower/Superpower.csproj
+++ b/src/Superpower/Superpower.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <Description>A parser combinator library for C#</Description>
-    <VersionPrefix>1.1.1</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Datalust;Superpower Contributors;Sprache Contributors</Authors>
     <TargetFrameworks>net45;netstandard1.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -18,24 +17,19 @@
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
   </PropertyGroup>
-  
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
-    
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DefineConstants>$(DefineConstants);CHECKED</DefineConstants>
   </PropertyGroup>
-
 </Project>

--- a/src/Superpower/Tokenizer`1.cs
+++ b/src/Superpower/Tokenizer`1.cs
@@ -1,4 +1,4 @@
-// Copyright 2016 Datalust, Superpower Contributors, Sprache Contributors
+// Copyright 2016-2018 Datalust, Superpower Contributors, Sprache Contributors
 //  
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,10 +51,12 @@ namespace Superpower
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
+            var state = new TokenizationState<TKind>();
+
             var sourceSpan = new TextSpan(source);
             var remainder = sourceSpan;
             var results = new List<Token<TKind>>();
-            foreach (var result in Tokenize(sourceSpan))
+            foreach (var result in Tokenize(sourceSpan, state))
             {
                 if (!result.HasValue)
                     return Result.CastEmpty<TKind, TokenList<TKind>>(result);
@@ -64,7 +66,7 @@ namespace Superpower
 
                 remainder = result.Remainder;
                 var token = new Token<TKind>(result.Value, result.Location.Until(result.Remainder));
-                Previous = token;
+                state.Previous = token;
                 results.Add(token);
             }
 
@@ -73,17 +75,27 @@ namespace Superpower
         }
 
         /// <summary>
-        /// The previous token parsed.
-        /// </summary>
-        protected Token<TKind> Previous { get; private set; }
-
-        /// <summary>
         /// Subclasses should override to perform tokenization.
         /// </summary>
         /// <param name="span">The input span to tokenize.</param>
         /// <returns>A list of parsed tokens.</returns>
-        protected abstract IEnumerable<Result<TKind>> Tokenize(TextSpan span);
+        protected virtual IEnumerable<Result<TKind>> Tokenize(TextSpan span)
+        {
+            throw new NotImplementedException("Either `Tokenize(TextSpan)` or `Tokenize(TextSpan, TokenizationState)` must be implemented.");
+        }
 
+        /// <summary>
+        /// Subclasses should override to perform tokenization when the
+        /// last-produced-token needs to be tracked.
+        /// </summary>
+        /// <param name="span">The input span to tokenize.</param>
+        /// <param name="state">The tokenization state maintained during the operation.</param>
+        /// <returns>A list of parsed tokens.</returns>
+        protected virtual IEnumerable<Result<TKind>> Tokenize(TextSpan span, TokenizationState<TKind> state)
+        {
+            return Tokenize(span);
+        }
+        
         /// <summary>
         /// Advance until the first non-whitespace character is encountered.
         /// </summary>

--- a/src/Superpower/Tokenizers/TokenizerBuilder.cs
+++ b/src/Superpower/Tokenizers/TokenizerBuilder.cs
@@ -1,0 +1,183 @@
+﻿// Copyright 2018 Datalust, Superpower Contributors, Sprache Contributors
+//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  
+//
+//     http://www.apache.org/licenses/LICENSE-2.0  
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Superpower.Model;
+
+namespace Superpower.Tokenizers
+{
+    /// <summary>
+    /// Builds a simple tokenizer given information about tokens and whitespace.
+    /// </summary>
+    /// <remarks>Provides a quick way to get started with a simple
+    /// tokenizer that matches the input against a list of possible token
+    /// recognizers.</remarks>
+    /// <typeparam name="TKind">The kind of token the tokenizer will
+    /// produce.</typeparam>
+    public class TokenizerBuilder<TKind>
+    {
+        struct Recognizer
+        {
+            public TextParser<Unit> Parser { get; }
+            public bool IsIgnored { get; }
+            public TKind Kind { get; }
+            public bool IsDelimiter { get; }
+
+            public Recognizer(TextParser<Unit> parser, bool isIgnored, TKind kind, bool isDelimiter)
+            {
+                Parser = parser;
+                IsIgnored = isIgnored;
+                Kind = kind;
+                IsDelimiter = isDelimiter;
+            }
+        }
+        
+        readonly List<Recognizer> _recognizers = new List<Recognizer>();
+        
+        /// <summary>
+        /// Add a recognizer for a kind of token. Recognizers are tried in the order
+        /// in which they are added.
+        /// </summary>
+        /// <param name="recognizer">A parser that will recognize the token.</param>
+        /// <param name="kind">The kind of token the recognizer will recognize.</param>
+        /// <param name="requireDelimiters">If true, the token must be preceded and followed
+        /// by either the beginning or end-of-input, an ignored (whitespace) character,
+        /// or a token kind that does not require delimiters. Generally set to `true` for
+        /// keywords/identifiers, otherwise, use the default value of `false`.</param>
+        /// <typeparam name="U">The value produced by the recognizer, if any. This
+        /// will be ignored.</typeparam>
+        /// <returns>The builder, to allow method chaining.</returns>
+        public TokenizerBuilder<TKind> Match<U>(TextParser<U> recognizer, TKind kind, bool requireDelimiters = false)
+        {
+            if (recognizer == null) throw new ArgumentNullException(nameof(recognizer));
+            _recognizers.Add(new Recognizer(
+                recognizer.Select(_ => Unit.Value), false, kind, !requireDelimiters));
+            return this;
+        }
+
+        /// <summary>
+        /// Add a recognizer for a whitespace/ignored text.
+        /// </summary>
+        /// <param name="ignored">A recognizer for the ignored text.</param>
+        /// <typeparam name="U">The value produced by the recognizer, if any. This
+        /// will be ignored.</typeparam>
+        /// <returns>The builder, to allow method chaining.</returns>
+        public TokenizerBuilder<TKind> Ignore<U>(TextParser<U> ignored)
+        {
+            if (ignored == null) throw new ArgumentNullException(nameof(ignored));
+            _recognizers.Add(new Recognizer(
+                ignored.Select(_ => Unit.Value), true, default(TKind), true));
+            return this;
+        }
+
+        /// <summary>
+        /// Build the tokenizer.
+        /// </summary>
+        /// <returns>The tokenizer.</returns>
+        public Tokenizer<TKind> Build()
+        {
+            return new SimpleLinearTokenizer(_recognizers);
+        }
+
+        class SimpleLinearTokenizer : Tokenizer<TKind>
+        {
+            readonly Recognizer[] _recognizers;
+
+            public SimpleLinearTokenizer(IEnumerable<Recognizer> recognizers)
+            {
+                if (recognizers == null) throw new ArgumentNullException(nameof(recognizers));
+                _recognizers = recognizers.ToArray();
+            }
+
+            protected override IEnumerable<Result<TKind>> Tokenize(TextSpan span)
+            {
+                var current = default(Result<TKind>);
+                var recognizerIndex = -1;
+                var hasCurrent = false;
+                var searchStart = 0;
+                
+                while (hasCurrent || TryMatch(span, searchStart, out current, out recognizerIndex))
+                {
+                    var recognizer = _recognizers[recognizerIndex];
+                    if (recognizer.IsIgnored)
+                    {
+                        hasCurrent = false;
+                        current = default(Result<TKind>);
+                        searchStart = 0;
+                        recognizerIndex = -1;
+                    }
+                    else if (recognizer.IsDelimiter || current.Remainder.IsAtEnd)
+                    {
+                        yield return current;
+                        hasCurrent = false;
+                        current = default(Result<TKind>);
+                        searchStart = 0;
+                        recognizerIndex = -1;
+                    }
+                    else if (TryMatch(current.Remainder, 0, out var next, out var nextRecognizerIndex) &&
+                        _recognizers[nextRecognizerIndex].IsDelimiter)
+                    {
+                        yield return current;
+                        hasCurrent = true;
+                        current = next;
+                        searchStart = 0;
+                        recognizerIndex = nextRecognizerIndex;
+                    }
+                    else if (recognizerIndex < _recognizers.Length - 1)
+                    {
+                        hasCurrent = false;
+                        current = default(Result<TKind>);
+                        searchStart = recognizerIndex + 1;
+                        recognizerIndex = -1;
+                    }
+                    else
+                    {
+                        yield break;
+                    }
+                }
+
+                if (!span.IsAtEnd)
+                {
+                    yield return Result.Empty<TKind>(span);
+                }
+            }
+
+            bool TryMatch(TextSpan span, int searchStart, out Result<TKind> match, out int recognizerIndex)
+            {
+                if (!span.IsAtEnd)
+                {
+                    while (searchStart < _recognizers.Length)
+                    {
+                        var recognizer = _recognizers[searchStart];
+                        var attempt = recognizer.Parser(span);
+                        if (attempt.HasValue && attempt.Remainder != span)
+                        {
+                            match = Result.Value(recognizer.Kind, span, attempt.Remainder);
+                            recognizerIndex = searchStart;
+                            return true;
+                        }
+
+                        searchStart++;
+                    }
+                }
+
+                match = default(Result<TKind>);
+                recognizerIndex = -1;
+                return false;
+            }
+        }
+    }
+}

--- a/test/Superpower.Benchmarks/Superpower.Benchmarks.csproj
+++ b/test/Superpower.Benchmarks/Superpower.Benchmarks.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Superpower.Benchmarks</AssemblyName>
     <PackageId>Superpower.Benchmarks</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">1.1.2</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/Superpower.Benchmarks/Superpower.Benchmarks.csproj
+++ b/test/Superpower.Benchmarks/Superpower.Benchmarks.csproj
@@ -17,9 +17,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="xunit" Version="2.3.0" />
     <PackageReference Include="BenchmarkDotNet" Version="0.10.10" />
     <PackageReference Include="Sprache" Version="2.1.0" />
   </ItemGroup>

--- a/test/Superpower.Benchmarks/Superpower.Benchmarks.csproj
+++ b/test/Superpower.Benchmarks/Superpower.Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Superpower.Benchmarks</AssemblyName>
     <PackageId>Superpower.Benchmarks</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/Superpower.Tests/ArithmeticExpressionScenario/ArithmeticExpressionTokenizer.cs
+++ b/test/Superpower.Tests/ArithmeticExpressionScenario/ArithmeticExpressionTokenizer.cs
@@ -24,15 +24,13 @@ namespace Superpower.Tests.ArithmeticExpressionScenario
 
             do
             {
-                ArithmeticExpressionToken charToken;
-
                 if (char.IsDigit(next.Value))
                 {
-                    var integer = Numerics.Integer(next.Location);
-                    next = integer.Remainder.ConsumeChar();
-                    yield return Result.Value(ArithmeticExpressionToken.Number, integer.Location, integer.Remainder);
+                    var natural = Numerics.Natural(next.Location);
+                    next = natural.Remainder.ConsumeChar();
+                    yield return Result.Value(ArithmeticExpressionToken.Number, natural.Location, natural.Remainder);
                 }
-                else if (_operators.TryGetValue(next.Value, out charToken))
+                else if (_operators.TryGetValue(next.Value, out var charToken))
                 {
                     yield return Result.Value(charToken, next.Location, next.Remainder);
                     next = next.Remainder.ConsumeChar();

--- a/test/Superpower.Tests/Parsers/NumericsTests.cs
+++ b/test/Superpower.Tests/Parsers/NumericsTests.cs
@@ -1,0 +1,43 @@
+﻿using Superpower.Parsers;
+using Superpower.Tests.Support;
+using Xunit;
+
+namespace Superpower.Tests.Parsers
+{
+    public class NumericsTests
+    {
+        [Theory]
+        [InlineData("0", true)]
+        [InlineData("01", true)]
+        [InlineData("910", true)]
+        [InlineData("-1", true)]
+        [InlineData("+1", true)]
+        [InlineData("1.1", false)]
+        [InlineData("a", false)]
+        [InlineData("", false)]
+        public void IntegersAreRecognized(string input, bool isMatch)
+        {
+            if (isMatch)
+                AssertParser.SucceedsWithAll(Numerics.Integer, input);
+            else
+                AssertParser.Fails(Numerics.Integer.AtEnd(), input);
+        }
+        
+        [Theory]
+        [InlineData("0", true)]
+        [InlineData("01", true)]
+        [InlineData("910", true)]
+        [InlineData("-1", false)]
+        [InlineData("+1", false)]
+        [InlineData("1.1", false)]
+        [InlineData("a", false)]
+        [InlineData("", false)]
+        public void NaturalNumbersAreRecognized(string input, bool isMatch)
+        {
+            if (isMatch)
+                AssertParser.SucceedsWithAll(Numerics.Natural, input);
+            else
+                AssertParser.Fails(Numerics.Natural.AtEnd(), input);
+        }
+    }
+}

--- a/test/Superpower.Tests/Parsers/SpanTests.cs
+++ b/test/Superpower.Tests/Parsers/SpanTests.cs
@@ -1,0 +1,31 @@
+﻿using Superpower.Model;
+using Superpower.Parsers;
+using Xunit;
+
+namespace Superpower.Tests.Parsers
+{
+    public class SpanTests
+    {
+        [Theory]
+        [InlineData("aaa", "aa", "aa")]
+        [InlineData("aaa", "a+", "aaa")]
+        [InlineData("aaa", "b", null)]
+        [InlineData("abcd", "bc", "bc", 1)]
+        [InlineData("abcd", "bc", null, 1, 1)]
+        public void RegularExpressionParsersAreApplied(
+            string input, 
+            string regex, 
+            string match, 
+            int start = 0,
+            int length = -1)
+        {
+            var parser = Span.Regex(regex);
+            var i = new TextSpan(input).Skip(start).First(length == -1 ? input.Length - start : length);
+            var r = parser(i);
+            if (match == null && !r.HasValue)
+                return; // Success, shouldn't have matched
+            
+            Assert.Equal(match, i.Until(r.Remainder).ToStringValue());
+        }
+    }
+}

--- a/test/Superpower.Tests/Superpower.Tests.csproj
+++ b/test/Superpower.Tests/Superpower.Tests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>
     <AssemblyName>Superpower.Tests</AssemblyName>
@@ -14,24 +13,19 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Superpower\Superpower.csproj" />
   </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <PackageReference Include="xunit" Version="2.3.0" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-
 </Project>

--- a/test/Superpower.Tests/Superpower.Tests.csproj
+++ b/test/Superpower.Tests/Superpower.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Superpower.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../asset/Superpower.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/Superpower.Tests/Superpower.Tests.csproj
+++ b/test/Superpower.Tests/Superpower.Tests.csproj
@@ -1,14 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <AssemblyName>Superpower.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../asset/Superpower.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Superpower.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/test/Superpower.Tests/Support/AssertParser.cs
+++ b/test/Superpower.Tests/Support/AssertParser.cs
@@ -37,6 +37,11 @@ namespace Superpower.Tests.Support
             Succeeds(parser, input, t => Assert.True(t.SequenceEqual(expectedResult)));
         }
 
+        public static void SucceedsWithAll(TextParser<TextSpan> parser, string input)
+        {
+            SucceedsWithAll(parser.Select(s => s.ToStringValue().ToCharArray()), input);
+        }
+        
         public static void SucceedsWithAll(TextParser<char[]> parser, string input)
         {
             SucceedsWithMany(parser, input, input.ToCharArray());

--- a/test/Superpower.Tests/Support/AssertParser.cs
+++ b/test/Superpower.Tests/Support/AssertParser.cs
@@ -27,7 +27,7 @@ namespace Superpower.Tests.Support
         {
             Succeeds(parser, input, t =>
             {
-                Assert.Equal(1, t.Count());
+                Assert.Single(t);
                 Assert.Equal(expectedResult, t.Single());
             });
         }
@@ -83,7 +83,7 @@ namespace Superpower.Tests.Support
         {
             Succeeds(parser, input, t =>
             {
-                Assert.Equal(1, t.Count());
+                Assert.Single(t);
                 Assert.Equal(expectedResult, t.Single());
             });
         }

--- a/test/Superpower.Tests/Support/PreviousCheckingTokenizer.cs
+++ b/test/Superpower.Tests/Support/PreviousCheckingTokenizer.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using Superpower.Model;
+using Xunit;
+
+namespace Superpower.Tests.Support
+{
+    public class PreviousCheckingTokenizer : Tokenizer<int>
+    {
+        protected override IEnumerable<Result<int>> Tokenize(TextSpan span, TokenizationState<int> state)
+        {
+            Assert.NotNull(state);            
+            Assert.Null(state.Previous);
+            var next = span.ConsumeChar();
+            yield return Result.Value(0, next.Location, next.Remainder);
+            
+            for (var i = 1; i < span.Length; ++i)
+            {
+                Assert.NotNull(state.Previous);
+                Assert.Equal(i - 1, state.Previous.Value.Kind);
+                next = next.Remainder.ConsumeChar();
+                yield return Result.Value(i, next.Location, next.Remainder);
+            }
+        }
+    }
+}

--- a/test/Superpower.Tests/Tokenizer`1Tests.cs
+++ b/test/Superpower.Tests/Tokenizer`1Tests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.CodeDom;
 using System.Linq;
 using Superpower.Tests.NumberListScenario;
+using Superpower.Tests.Support;
 using Xunit;
 
 namespace Superpower.Tests
@@ -13,7 +15,7 @@ namespace Superpower.Tests
             var tokenizer = new NumberListTokenizer();
             var result = tokenizer.TryTokenize("1 a");
             Assert.False(result.HasValue);
-            Assert.Equal(result.FormatErrorMessageFragment(), "unexpected `a`, expected digit");
+            Assert.Equal("unexpected `a`, expected digit", result.FormatErrorMessageFragment());
         }
 
         [Fact]
@@ -22,7 +24,7 @@ namespace Superpower.Tests
             var tokenizer = new NumberListTokenizer(useCustomErrors: true);
             var result = tokenizer.TryTokenize("1 a");
             Assert.False(result.HasValue);
-            Assert.Equal(result.FormatErrorMessageFragment(), "list must contain only numbers");
+            Assert.Equal("list must contain only numbers", result.FormatErrorMessageFragment());
         }
 
         [Fact]
@@ -51,7 +53,10 @@ namespace Superpower.Tests
         [Fact]
         public void TokenizationStateTracksTheLastProducedToken()
         {
-            throw new NotImplementedException();
+            var tokenizer = new PreviousCheckingTokenizer();
+            var input = new string('_', 6);
+            var result = tokenizer.Tokenize(input);
+            Assert.Equal(input.Length, result.Count());
         }
     }
 }

--- a/test/Superpower.Tests/Tokenizer`1Tests.cs
+++ b/test/Superpower.Tests/Tokenizer`1Tests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Superpower.Tests.NumberListScenario;
 using Xunit;
 
@@ -48,6 +46,12 @@ namespace Superpower.Tests
             var tokenizer = new NumberListTokenizer();
             var result = tokenizer.Tokenize("1 23 456");
             Assert.Equal(3, result.Count());
+        }
+
+        [Fact]
+        public void TokenizationStateTracksTheLastProducedToken()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/test/Superpower.Tests/Tokenizers/TokenizerBuilderTests.cs
+++ b/test/Superpower.Tests/Tokenizers/TokenizerBuilderTests.cs
@@ -1,0 +1,27 @@
+﻿using System.Linq;
+using Superpower.Parsers;
+using Superpower.Tests.SExpressionScenario;
+using Superpower.Tokenizers;
+using Xunit;
+
+namespace Superpower.Tests.Tokenizers
+{
+    public class TokenizerBuilderTests
+    {
+        [Fact]
+        public void SExpressionsCanBeTokenized()
+        {
+            var tokenizer = new TokenizerBuilder<SExpressionToken>()
+                .Ignore(Span.WhiteSpace)
+                .Match(Character.EqualTo('('), SExpressionToken.LParen)
+                .Match(Character.EqualTo(')'), SExpressionToken.RParen)
+                .Match(Numerics.Integer, SExpressionToken.Number)
+                .Match(Span.While(char.IsLetterOrDigit), SExpressionToken.Atom)
+                .Build();
+
+            var tokens = tokenizer.TryTokenize("abc (123 def)");
+            Assert.True(tokens.HasValue);
+            Assert.Equal(5, tokens.Value.Count());
+        }
+    }
+}


### PR DESCRIPTION
I'm working on this monolithic changeset in an effort to streamline a lot of the tokenization-side of the library. There are breaking changes here that need to be documented before this will be ready to go.

**Edit:**

 * Implements #26 - `TokenizerBuilder`
 * Fixes #12 - removes `Tokenizer.Previous` - **breaking**
 * Accept a sign `+/-` to `Numerics.Integer`, introduces `Numerics.Natural` with the old behavior
 * Introduces some new recognizers and parsers
  - `Comment.CStyle`, `CPlusPlusStyle`, `SqlStyle`, ShellStyle` and `ToEndOfLine(p)`
  - `Span.Regex()`
  - `Numerics.IntegerInt64`, `Numerics.Natural*` variants
 * Adds `TextSpan.Skip()` and `IsMatch()` extension on text parsers
 * `Span.While()` and `Span.Until()` renamed `Span.WithoutAny()` and `Span.WithAll()`, no longer accept zero-length matches - **breaking**

To do:

 - [ ] Update the README showing how the `TokenizerBuilder` works
