### PR TITLE
 A number of handy additional text parsers

### DIFF
--- a/src/Superpower/Combinators.cs
+++ b/src/Superpower/Combinators.cs
@@ -612,6 +612,37 @@ namespace Superpower
         }
 
         /// <summary>
+        /// Construct a parser that takes the result of <paramref name="parser"/> and casts it to <typeparamref name="U"/>.
+        /// </summary>
+        /// <typeparam name="TKind">The kind of the tokens being parsed.</typeparam>
+        /// <typeparam name="T">The type of value being parsed.</typeparam>
+        /// <typeparam name="U">The type of the resulting value.</typeparam>
+        /// <param name="parser">The parser.</param>
+        /// <returns>The resulting parser.</returns>
+        public static TokenListParser<TKind, U> Cast<TKind, T, U>(this TokenListParser<TKind, T> parser)
+            where T: U
+        {
+            if (parser == null) throw new ArgumentNullException(nameof(parser));
+
+            return parser.Then(rt => Parse.Return<TKind, U>((U)rt));
+        }
+        
+        /// <summary>
+        /// Construct a parser that takes the result of <paramref name="parser"/> and casts it to <typeparamref name="U"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of value being parsed.</typeparam>
+        /// <typeparam name="U">The type of the resulting value.</typeparam>
+        /// <param name="parser">The parser.</param>
+        /// <returns>The resulting parser.</returns>
+        public static TextParser<U> Cast<T, U>(this TextParser<T> parser)
+            where T: U
+        {
+            if (parser == null) throw new ArgumentNullException(nameof(parser));
+
+            return parser.Then(rt => Parse.Return((U)rt));
+        }
+
+        /// <summary>
         /// The LINQ query comprehension pattern.
         /// </summary>
         /// <typeparam name="T">The type of value being parsed.</typeparam>

--- a/src/Superpower/Parsers/Identifier.cs
+++ b/src/Superpower/Parsers/Identifier.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2018 Datalust, Superpower Contributors, Sprache Contributors
+//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  
+//
+//     http://www.apache.org/licenses/LICENSE-2.0  
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Superpower.Model;
+
+namespace Superpower.Parsers
+{
+    /// <summary>
+    /// Parsers for matching identifiers in various styles.
+    /// </summary>
+    public static class Identifier
+    {
+        /// <summary>
+        /// Parse a <code>C_Style</code> identifier.
+        /// </summary>
+        public static TextParser<TextSpan> CStyle { get; } =
+            Span.MatchedBy(
+                Character.Letter.Or(Character.EqualTo('_'))
+                    .IgnoreThen(Character.LetterOrDigit.Or(Character.EqualTo('_')).Many()));
+    }
+}

--- a/src/Superpower/Parsers/Instant.cs
+++ b/src/Superpower/Parsers/Instant.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2018 Datalust, Superpower Contributors, Sprache Contributors
+//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  
+//
+//     http://www.apache.org/licenses/LICENSE-2.0  
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Superpower.Model;
+
+namespace Superpower.Parsers
+{
+    /// <summary>
+    /// Parsers for matching date and time formats.
+    /// </summary>
+    public static class Instant
+    {
+        /// <summary>
+        /// Matches ISO-8601 datetimes.
+        /// </summary>
+        public static TextParser<TextSpan> Iso8601DateTime { get; } =
+            Span.Regex("\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?");
+    }
+}

--- a/src/Superpower/Parsers/Numerics.cs
+++ b/src/Superpower/Parsers/Numerics.cs
@@ -194,5 +194,23 @@ namespace Superpower.Parsers
             
             return Result.Value(val, input, remainder);
         };
+        
+        /// <summary>
+        /// Matches decimal numbers, for example <code>-1.23</code>.
+        /// </summary>
+        public static TextParser<TextSpan> Decimal { get; } =
+            Integer
+                .Then(n => Character.EqualTo('.').IgnoreThen(Natural).OptionalOrDefault()
+                    .Select(f => f == TextSpan.None ? n : new TextSpan(n.Source, n.Position, n.Length + f.Length + 1)));
+
+        /// <summary>
+        /// Matches <code>0x</code>-prefixed hexadecimal numbers.
+        /// </summary>
+        public static TextParser<TextSpan> HexNatural { get; } =
+            Span.MatchedBy(Span.EqualTo("0x")
+                .IgnoreThen(Character.Digit
+                    .Or(Character.Matching(ch => ch >= 'a' && ch <= 'f' || ch >= 'A' && ch <= 'F', "a-f"))
+                    .Named("hex digit")
+                    .AtLeastOnce()));
     }
 }

--- a/src/Superpower/Parsers/Numerics.cs
+++ b/src/Superpower/Parsers/Numerics.cs
@@ -25,6 +25,7 @@ namespace Superpower.Parsers
     {
         static readonly string[] ExpectedDigit = { "digit" };
         static readonly string[] ExpectedSignOrDigit = { "sign", "digit" };
+        static readonly string[] ExpectedHexDigit = { "hex digit" };
 
         /// <summary>
         /// A string of digits.
@@ -203,14 +204,72 @@ namespace Superpower.Parsers
                 .Then(n => Character.EqualTo('.').IgnoreThen(Natural).OptionalOrDefault()
                     .Select(f => f == TextSpan.None ? n : new TextSpan(n.Source, n.Position, n.Length + f.Length + 1)));
 
+        static bool IsHexDigit(char ch)
+        {
+            return char.IsDigit(ch) || ch >= 'a' && ch <= 'f' || ch >= 'A' && ch <= 'F';
+        }
+
+        static int HexValue(char ch)
+        {
+            if (char.IsDigit(ch))
+                return ch - '0';
+
+            if (ch >= 'a' && ch <= 'f')
+                return 15 + ch - 'f';
+
+            return 15 + ch - 'F';
+        }
+
+        static TextParser<char> HexDigit { get; } = Character.Matching(IsHexDigit, "hex digit");
+
         /// <summary>
-        /// Matches <code>0x</code>-prefixed hexadecimal numbers.
+        /// Matches hexadecimal numbers.
         /// </summary>
-        public static TextParser<TextSpan> HexNatural { get; } =
-            Span.MatchedBy(Span.EqualTo("0x")
-                .IgnoreThen(Character.Digit
-                    .Or(Character.Matching(ch => ch >= 'a' && ch <= 'f' || ch >= 'A' && ch <= 'F', "a-f"))
-                    .Named("hex digit")
-                    .AtLeastOnce()));
+        public static TextParser<TextSpan> HexDigits { get; } =
+            Span.MatchedBy(HexDigit.AtLeastOnce());  
+        
+        /// <summary>
+        /// A string of hexadecimal digits, converted into a <see cref="uint"/>.
+        /// </summary>
+        public static TextParser<uint> HexDigitsUInt32 { get; } = input =>
+        {
+            var next = input.ConsumeChar();
+            
+            if (!next.HasValue || !IsHexDigit(next.Value))
+                return Result.Empty<uint>(input, ExpectedHexDigit);
+
+            TextSpan remainder;
+            var val = 0u;
+            do
+            {
+                val = 16 * val + (uint)HexValue(next.Value);
+                remainder = next.Remainder;
+                next = remainder.ConsumeChar();
+            } while (next.HasValue && IsHexDigit(next.Value));
+            
+            return Result.Value(val, input, remainder);
+        };
+                
+        /// <summary>
+        /// A string of hexadecimal digits, converted into a <see cref="ulong"/>.
+        /// </summary>
+        public static TextParser<ulong> HexDigitsUInt64 { get; } = input =>
+        {
+            var next = input.ConsumeChar();
+            
+            if (!next.HasValue || !IsHexDigit(next.Value))
+                return Result.Empty<ulong>(input, ExpectedHexDigit);
+
+            TextSpan remainder;
+            var val = 0ul;
+            do
+            {
+                val = 16 * val + (ulong)HexValue(next.Value);
+                remainder = next.Remainder;
+                next = remainder.ConsumeChar();
+            } while (next.HasValue && IsHexDigit(next.Value));
+            
+            return Result.Value(val, input, remainder);
+        };
     }
 }

--- a/src/Superpower/Parsers/QuotedString.cs
+++ b/src/Superpower/Parsers/QuotedString.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2018 Datalust, Superpower Contributors, Sprache Contributors
+//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  
+//
+//     http://www.apache.org/licenses/LICENSE-2.0  
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Superpower.Parsers
+{
+    /// <summary>
+    /// Parsers for matching strings in various styles.
+    /// </summary>
+    public static class QuotedString
+    {
+        static readonly TextParser<char> SqlStringContentChar =
+            Span.EqualTo("''").Value('\'').Try().Or(Character.ExceptIn('\'', '\r', '\n'));
+
+        /// <summary>
+        /// A <code>'SQL-style'</code> string. Single quote delimiters, with embedded single quotes
+        /// escaped by '' doubling.
+        /// </summary>
+        public static TextParser<string> SqlStyle { get; } =
+            Character.EqualTo('\'')
+                .IgnoreThen(SqlStringContentChar.Many())
+                .Then(s => Character.EqualTo('\'').Value(new string(s)));
+    }
+}

--- a/src/Superpower/Parsers/Span.cs
+++ b/src/Superpower/Parsers/Span.cs
@@ -200,6 +200,11 @@ namespace Superpower.Parsers
                 Result.Empty<TextSpan>(input) :
                 Result.Value(input.Until(next.Location), input, next.Location);
         };
+       
+        /// <summary>
+        /// Parse until a whitespace character is encountered, returning the matched span of non-whitespace characters.
+        /// </summary>
+        public static TextParser<TextSpan> NonWhiteSpace { get; } = WithoutAny(char.IsWhiteSpace);
 
         /// <summary>
         /// Parse as much of the input as matches <paramref name="regex" />.
@@ -225,6 +230,29 @@ namespace Superpower.Parsers
                     remainder = remainder.ConsumeChar().Remainder;
 
                 return Result.Value(i.First(m.Length), i, remainder);
+            };
+        }
+        
+        /// <summary>
+        /// A handy adapter that takes any text parser, regardless of its result
+        /// type, and returns the span consumed by that parser.
+        /// </summary>
+        /// <param name="parser">A parser to apply.</param>
+        /// <typeparam name="T">The parser's (ignored) result type.</typeparam>
+        /// <returns>A parser that will match the span covered by <paramref name="parser"/>.</returns>
+        public static TextParser<TextSpan> MatchedBy<T>(TextParser<T> parser)
+        {
+            return i =>
+            {
+                var result = parser(i);
+                
+                if (!result.HasValue)
+                    return Result.CastEmpty<T, TextSpan>(result);
+              
+                return Result.Value(
+                    i.Until(result.Remainder),
+                    i,
+                    result.Remainder);
             };
         }
     }

--- a/test/Superpower.Tests/Parsers/IdentifierTests.cs
+++ b/test/Superpower.Tests/Parsers/IdentifierTests.cs
@@ -1,0 +1,39 @@
+﻿using Superpower.Model;
+using Superpower.Parsers;
+using Superpower.Tests.Support;
+using Xunit;
+
+namespace Superpower.Tests.Parsers
+{
+    public class IdentifierTests
+    {
+        [Fact]
+        public void CStyleIdentifiersAreMatched()
+        {
+            var input = new TextSpan("C_Style!");
+            var r = Identifier.CStyle(input);
+            Assert.Equal("C_Style", r.Value.ToStringValue());
+        }
+
+        [Fact]
+        public void CStyleIdentifiersMayStartWithLeadingUnderscore()
+        {
+            var input = new TextSpan("_cStyle1!");
+            var r = Identifier.CStyle(input);
+            Assert.Equal("_cStyle1", r.Value.ToStringValue());
+        }
+        
+        [Theory]
+        [InlineData("0", false)]
+        [InlineData("__", true)]
+        [InlineData("A0", true)]
+        [InlineData("ab", true)]
+        [InlineData("a_b", true)]
+        [InlineData("_b", true)]
+        [InlineData("1CStyle", false)]
+        public void CStyleIdentifiersAreRecognized(string input, bool isMatch)
+        {
+            AssertParser.FitsTheory(Identifier.CStyle, input, isMatch);
+        }
+    }
+}

--- a/test/Superpower.Tests/Parsers/InstantTests.cs
+++ b/test/Superpower.Tests/Parsers/InstantTests.cs
@@ -1,0 +1,23 @@
+﻿using Superpower.Parsers;
+using Superpower.Tests.Support;
+using Xunit;
+
+namespace Superpower.Tests.Parsers
+{
+    public class InstantTests
+    {
+        [Theory]
+        [InlineData("0", false)]
+        [InlineData("1910-10-28T03:04:05", true)]
+        [InlineData("2020-10-28T03:04:05", true)]
+        [InlineData("1910-10-28T03:04:05.6789", true)]
+        [InlineData("1910-10-28T03:04:05Z", true)]
+        [InlineData("1910-10-28T03:04:05+10:00", true)]
+        [InlineData("1910-10-28T03:04:05-07:30", true)]
+        // A number of cases allowed by the spec aren't yet covered, here.
+        public void IsoDateTimesAreRecognized(string input, bool isMatch)
+        {
+            AssertParser.FitsTheory(Instant.Iso8601DateTime, input, isMatch);
+        }        
+    }
+}

--- a/test/Superpower.Tests/Parsers/NumericsTests.cs
+++ b/test/Superpower.Tests/Parsers/NumericsTests.cs
@@ -17,10 +17,7 @@ namespace Superpower.Tests.Parsers
         [InlineData("", false)]
         public void IntegersAreRecognized(string input, bool isMatch)
         {
-            if (isMatch)
-                AssertParser.SucceedsWithAll(Numerics.Integer, input);
-            else
-                AssertParser.Fails(Numerics.Integer.AtEnd(), input);
+            AssertParser.FitsTheory(Numerics.Integer, input, isMatch);
         }
         
         [Theory]
@@ -34,10 +31,43 @@ namespace Superpower.Tests.Parsers
         [InlineData("", false)]
         public void NaturalNumbersAreRecognized(string input, bool isMatch)
         {
-            if (isMatch)
-                AssertParser.SucceedsWithAll(Numerics.Natural, input);
-            else
-                AssertParser.Fails(Numerics.Natural.AtEnd(), input);
+            AssertParser.FitsTheory(Numerics.Natural, input, isMatch);
+        }
+        
+        [Theory]
+        [InlineData("0", false)]
+        [InlineData("a", false)]
+        [InlineData("0x-1", false)]
+        [InlineData("0x910", true)]
+        [InlineData("0x0", true)]
+        [InlineData("0xa", true)]
+        [InlineData("0xA", true)]
+        [InlineData("0x0123456789abcdef", true)]
+        [InlineData("0xg", false)]
+        [InlineData("", false)]
+        public void HexNaturalNumbersAreRecognized(string input, bool isMatch)
+        {
+            AssertParser.FitsTheory(Numerics.HexNatural, input, isMatch);
+        }
+        
+        [Theory]
+        [InlineData("0", true)]
+        [InlineData("01", true)]
+        [InlineData("910", true)]
+        [InlineData("-1", true)]
+        [InlineData("+1", true)]
+        [InlineData("1.1", true)]
+        [InlineData("-1.1", true)]
+        [InlineData("a", false)]
+        [InlineData("", false)]
+        [InlineData("123.456", true)]
+        [InlineData("123.+456", false)]
+        [InlineData("123.", false)]
+        [InlineData(".456", false)]
+        [InlineData("-.456", false)]
+        public void DecimalNumbersAreRecognized(string input, bool isMatch)
+        {
+            AssertParser.FitsTheory(Numerics.Decimal, input, isMatch);
         }
     }
 }

--- a/test/Superpower.Tests/Parsers/NumericsTests.cs
+++ b/test/Superpower.Tests/Parsers/NumericsTests.cs
@@ -35,21 +35,33 @@ namespace Superpower.Tests.Parsers
         }
         
         [Theory]
-        [InlineData("0", false)]
-        [InlineData("a", false)]
-        [InlineData("0x-1", false)]
-        [InlineData("0x910", true)]
-        [InlineData("0x0", true)]
-        [InlineData("0xa", true)]
-        [InlineData("0xA", true)]
-        [InlineData("0x0123456789abcdef", true)]
-        [InlineData("0xg", false)]
+        [InlineData("0", true)]
+        [InlineData("-1", false)]
+        [InlineData("910", true)]
+        [InlineData("0x123", false)]
+        [InlineData("a", true)]
+        [InlineData("A", true)]
+        [InlineData("0123456789abcdef", true)]
+        [InlineData("g", false)]
         [InlineData("", false)]
-        public void HexNaturalNumbersAreRecognized(string input, bool isMatch)
+        public void HexDigitsAreRecognized(string input, bool isMatch)
         {
-            AssertParser.FitsTheory(Numerics.HexNatural, input, isMatch);
+            AssertParser.FitsTheory(Numerics.HexDigits, input, isMatch);
         }
         
+        [Theory]
+        [InlineData("0", 0)]
+        [InlineData("a", 0xa)]
+        [InlineData("910", 0x910)]
+        [InlineData("A", 0xA)]
+        [InlineData("012345678", 0x12345678)]
+        [InlineData("9abcdef", 0x9abcdef)]
+        public void HexDigitsAreParsed(string input, uint value)
+        {
+            var parsed = Numerics.HexDigitsUInt32.Parse(input);
+            Assert.Equal(value, parsed);
+        }
+
         [Theory]
         [InlineData("0", true)]
         [InlineData("01", true)]

--- a/test/Superpower.Tests/Parsers/QuotedStringTests.cs
+++ b/test/Superpower.Tests/Parsers/QuotedStringTests.cs
@@ -1,0 +1,18 @@
+﻿using Superpower.Model;
+using Superpower.Parsers;
+using Xunit;
+
+namespace Superpower.Tests.Parsers
+{    
+    public class QuotedStringTests
+    {
+        [Fact]
+        public void SqlStyleStringsAreParsed()
+        {
+            var input = new TextSpan("'Hello, ''world''!'x");
+            var parser = QuotedString.SqlStyle;
+            var r = parser(input);
+            Assert.Equal("Hello, 'world'!", r.Value);
+        }
+    }
+}

--- a/test/Superpower.Tests/Parsers/SpanTests.cs
+++ b/test/Superpower.Tests/Parsers/SpanTests.cs
@@ -27,5 +27,50 @@ namespace Superpower.Tests.Parsers
             
             Assert.Equal(match, i.Until(r.Remainder).ToStringValue());
         }
+    
+        [Fact]
+        public void WhiteSpaceMatches()
+        {
+            var parser = Span.WhiteSpace;
+            var input = new TextSpan("  a");
+            var r = parser(input);
+            Assert.True(r.Value.ToStringValue() == "  ");
+        }
+    
+        [Fact]
+        public void WhiteSpaceDoesNotMatchZeroLength()
+        {
+            var parser = Span.WhiteSpace;
+            var input = new TextSpan("a");
+            var r = parser(input);
+            Assert.False(r.HasValue);
+        }
+    
+        [Fact]
+        public void NonWhiteSpaceMatches()
+        {
+            var parser = Span.NonWhiteSpace;
+            var input = new TextSpan("ab ");
+            var r = parser(input);
+            Assert.True(r.Value.ToStringValue() == "ab");
+        }
+
+        [Fact]
+        public void NonWhiteSpaceDoesNotMatchZeroLength()
+        {
+            var parser = Span.NonWhiteSpace;
+            var input = new TextSpan(" ");
+            var r = parser(input);
+            Assert.False(r.HasValue);
+        }
+
+        [Fact]
+        public void MatchedByReturnsTheSpanMatchedByAParser()
+        {
+            var parser = Span.MatchedBy(Numerics.IntegerInt32);
+            var input = new TextSpan("123abc");
+            var r = parser(input);
+            Assert.Equal(r.Value.ToStringValue(), "123");
+        }
     }
 }

--- a/test/Superpower.Tests/Support/AssertParser.cs
+++ b/test/Superpower.Tests/Support/AssertParser.cs
@@ -163,6 +163,14 @@ namespace Superpower.Tests.Support
             var result = parser.TryParse(StringAsCharTokenList.Tokenize(input));
             Assert.Equal(message, result.ToString());
         }
+
+        public static void FitsTheory(TextParser<TextSpan> parser, string input, bool isMatch)
+        {
+            if (isMatch)
+                SucceedsWithAll(parser, input);
+            else
+                Fails(parser.AtEnd(), input);
+        }
     }
 }
 


### PR DESCRIPTION
These came out of building the plain text matchers for https://github.com/datalust/seqcli. They're useful for building tokenizers, which we can take advantage of via #26 when it's baked.

Unlike most of the other parsers already in here, they're constructed simply and not fully-optimized. There's a long way to go before we'll have a respectable library of pre-built parsers here, so seems worthwhile to build it out quickly and optimize later.

The ISO-8601 date time parser makes use of regular expression matching, and expects a full date and time component to be present. A good ISO-8601 parser is a mini-project in itself; hopefully this one is a starting point from which we or others can build.