### PR TITLE
Improve `TokenizerBuilder` error reporting 

### DIFF
--- a/src/Superpower/Model/Result`1.cs
+++ b/src/Superpower/Model/Result`1.cs
@@ -43,6 +43,7 @@ namespace Superpower.Model
         /// <summary>
         /// The position of the first un-parsed location.
         /// </summary>
+        // ReSharper disable once UnusedMember.Global
         public Position ErrorPosition => Remainder.Position;
 
         /// <summary>
@@ -55,7 +56,7 @@ namespace Superpower.Model
         /// </summary>
         public string[] Expectations { get; }
 
-        internal bool IsPartial(TextSpan @from) => @from != Remainder;
+        internal bool IsPartial(TextSpan from) => from != Remainder;
 
         internal bool Backtrack { get; set; }
 

--- a/src/Superpower/Tokenizers/TokenizerBuilder.cs
+++ b/src/Superpower/Tokenizers/TokenizerBuilder.cs
@@ -103,6 +103,13 @@ namespace Superpower.Tokenizers
                 _recognizers = recognizers.ToArray();
             }
 
+            /// <remarks>
+            /// The complexity in this method is due to the desire to distinguish between (e.g. in C#)
+            /// the keyworkd `null` vs the identifier `nullability`. The tokenizer, when it encounters
+            /// a non-delimiter match (like `null`), looks ahead to see whether it's immediately followed
+            /// by a delimiter or end-of-input. If not, the match is discarded and subsequent recognizers
+            /// are tested.
+            /// </remarks>
             protected override IEnumerable<Result<TKind>> Tokenize(TextSpan span)
             {
                 var remainder = span;
@@ -154,10 +161,23 @@ namespace Superpower.Tokenizers
                     }
                 }
 
-                if (!remainder.IsAtEnd)
+                if (remainder.IsAtEnd)
+                    yield break;
+
+                // Even though this re-runs all of the recognizers, it's better for performance
+                // to calculate the error here, than do all of the extra work in the hot/success path.
+                var failure = Result.Empty<TKind>(span);
+                foreach (var recognizer in _recognizers)
                 {
-                    yield return Result.Empty<TKind>(span);
+                    var attempt = recognizer.Parser(span);
+                    if (!attempt.HasValue && // <- Successful recognizers rejected because delimiters were not present
+                        attempt.ErrorPosition.Absolute > failure.ErrorPosition.Absolute)
+                    {
+                        failure = Result.CastEmpty<Unit, TKind>(attempt);
+                    }
                 }
+
+                yield return failure;;
             }
 
             bool TryMatch(TextSpan span, int searchStart, out Result<TKind> match, out int recognizerIndex)

--- a/test/Superpower.Tests/Tokenizers/TokenizerBuilderTests.cs
+++ b/test/Superpower.Tests/Tokenizers/TokenizerBuilderTests.cs
@@ -39,5 +39,19 @@ namespace Superpower.Tests.Tokenizers
             Assert.Equal(7, tokens.Value.Count());
             Assert.Equal(3, tokens.Value.Count(v => v.Kind));
         }
+
+        [Fact]
+        public void PartiallyFailedTokenizationIsReported()
+        {
+            var tokenizer = new TokenizerBuilder<string>()
+                .Match(Span.EqualTo("abc"), "abc")
+                .Match(Span.EqualTo("def"), "def")
+                .Build();
+
+            var tokens = tokenizer.TryTokenize("abd");
+            Assert.False(tokens.HasValue);
+            var msg = tokens.ToString();
+            Assert.Equal("Syntax error (line 1, column 3): unexpected `d`, expected `c`.", msg);
+        }
     }
 }

--- a/test/Superpower.Tests/Tokenizers/TokenizerBuilderTests.cs
+++ b/test/Superpower.Tests/Tokenizers/TokenizerBuilderTests.cs
@@ -44,14 +44,15 @@ namespace Superpower.Tests.Tokenizers
         public void PartiallyFailedTokenizationIsReported()
         {
             var tokenizer = new TokenizerBuilder<string>()
+                .Ignore(Span.WhiteSpace)
                 .Match(Span.EqualTo("abc"), "abc")
                 .Match(Span.EqualTo("def"), "def")
                 .Build();
 
-            var tokens = tokenizer.TryTokenize("abd");
+            var tokens = tokenizer.TryTokenize(" abd");
             Assert.False(tokens.HasValue);
             var msg = tokens.ToString();
-            Assert.Equal("Syntax error (line 1, column 3): unexpected `d`, expected `c`.", msg);
+            Assert.Equal("Syntax error (line 1, column 4): invalid abc, unexpected `d`, expected `c`.", msg);
         }
     }
 }


### PR DESCRIPTION
Deals with this case:

```csharp
[Fact]
public void PartiallyFailedTokenizationIsReported()
{
    var tokenizer = new TokenizerBuilder<string>()
        .Match(Span.EqualTo("abc"), "abc")
        .Match(Span.EqualTo("def"), "def")
        .Build();

    var tokens = tokenizer.TryTokenize("abd");
    Assert.False(tokens.HasValue);
    var msg = tokens.ToString();
    Assert.Equal("Syntax error (line 1, column 3): unexpected `d`, expected `c`.", msg);
}
```

Previously this would have simply reported _unexpected \`a\`_.

The longest match is used when reporting the error, with top-to-bottom precedent respected.

Also updates the README to show only `TokenizerBuilder` and reference some handwritten examples, since the code that was there is really quite confronting :-)