### PR TITLE
Repeat combinator

### DIFF
--- a/sample/DateTimeTextParser/DateTimeParser.csproj
+++ b/sample/DateTimeTextParser/DateTimeParser.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Superpower\Superpower.csproj" />

--- a/sample/DateTimeTextParser/Program.cs
+++ b/sample/DateTimeTextParser/Program.cs
@@ -1,38 +1,33 @@
 ﻿using System;
-using Superpower;
 
-namespace DateTimeTextParser
+namespace DateTimeParser
 {
-    class Program
+    static class Program
     {
         static void ParseAndPrint(string input)
         {
             try
             {
-                var dt = DateTimeTextParser.DateTime.Parse(input);
-                Console.WriteLine("Input: '{0}', ParsedValue: '{1}'", input, dt.ToString("o"));
+                var dt = DateTimeTextParser.Parse(input);
+                Console.WriteLine("Input: \"{0}\", Parsed value: \"{1:o}\"", input, dt);
             }
-            catch (System.Exception ex)
+            catch (Exception ex)
             {
                 Console.ForegroundColor = ConsoleColor.Red;
-                Console.WriteLine("Input: '{0}'", input);
+                Console.WriteLine("Input: \"{0}\"", input);
                 Console.WriteLine(ex.ToString());
                 Console.ForegroundColor = ConsoleColor.White;
             }
         }
 
-        static void Main(string[] args)
+        static void Main()
         {
-            ParseAndPrint("12:38");
-            ParseAndPrint("12:38:10");
             ParseAndPrint("2017-01-01");
             ParseAndPrint("2017-01-01 05:28:10");
             ParseAndPrint("2017-01-01 05:28");
-            ParseAndPrint("\"2017-01-01\"");
-            ParseAndPrint("\"2017-01-01");
-            ParseAndPrint("2017-01-01 05:x8:10");
             ParseAndPrint("2017-01-01T05:28:10");
             ParseAndPrint("2017-01-01T05:28");
+            ParseAndPrint("2017-01-01 05:x8:10");
         }
     }
 }

--- a/sample/DateTimeTextParser/README.md
+++ b/sample/DateTimeTextParser/README.md
@@ -1,58 +1,12 @@
 # Superpower sample / `DateTimeTextParser`
 
-This example should shows how to build a simple text parser with Superpower.
+This example shows how to build a simple text parser with Superpower.
 It uses a simple and well known requirement: parsing date and time values 
-according to ISO-8601 format.
-
-## The requirement
-
-In a simple, custom query language a user enters multiple conditions where a
-property is compared to a static value. The property identifier the
-comparison operator and the static value had to be separated with spaces.
-There are text properties and datetime properties to query.
-
-The static text values had to be entered enclosed with `'"'` (double qoutes),
-datetime static values can be entered as date, time or date and time. For
-better usability not only text can be enclosed with `'"'`, also the date time
-static values can be surrounded with double qoutes. When only time is entered
-it should be considered as todays time. When only date is entered midnight is
-the default time value.
+according to ISO-8601 format. (Time zones and fractional seconds are not
+covered by the example.
 
 For example:
-- `2017-01-01 12:10`
-- `"2017-01-01 12:10"`
-- `12:10`
-- `2017-01-01`
 
-## The code
-
-The `DateTimeTextParser` class contains the `DateTime` Superpower `TextParser`, which 
-covers all the requirements to parse a static datetime value.
-
-```cs
-public static TextParser<DateTime> DateTime = 
-      from q1 in Character.EqualTo('"').Optional()
-//    ^- First we looking for a optional double quote
-
-      from date in (from date in Date
-                    from s in Character.In('T', ' ')
-                    from time in Time
-                    select date + time).Try()
-//                  ^- here we're looking for date and time values
-
-                    .Or(from time in Time
-                        select System.DateTime.Now.Date + time).Try()
-//                  ^- when the first parser failed check for time only
-//                     and add it to the current date
-
-                    .Or(Date)
-//                  ^- else it must be a date value  
-
-      from q2 in Character.EqualTo('"').Optional().AtEnd()
-//    ^- then we check for a optional double quote at the end of the input
-
-      where (q1 == null && q2 == null) || (q1 != null && q2 != null)
-//    ^- now we're checking if both quote are either set or not set
-
-      select date;
-```
+ - `2017-01-01`
+ - `2017-01-01 12:10`
+ - `2017-01-01 12:10:30`

--- a/test/Superpower.Tests/Combinators/RepeatCombinatorTests.cs
+++ b/test/Superpower.Tests/Combinators/RepeatCombinatorTests.cs
@@ -1,0 +1,57 @@
+﻿using Superpower.Parsers;
+using Superpower.Tests.Support;
+using Xunit;
+
+namespace Superpower.Tests.Combinators
+{
+    public class RepeatCombinatorTests
+    {
+        [Fact]
+        public void RepeatSucceedsWithNone()
+        {
+            AssertParser.SucceedsWithAll(Character.EqualTo('a').Repeat(0), "");
+        }
+
+        [Fact]
+        public void RepeatSucceedsWithOne()
+        {
+            AssertParser.SucceedsWithAll(Character.EqualTo('a').Repeat(1), "a");
+        }
+
+        [Fact]
+        public void RepeatSucceedsWithTwo()
+        {
+            AssertParser.SucceedsWithAll(Character.EqualTo('a').Repeat(2), "aa");
+        }
+
+        [Fact]
+        public void RepeatFailsWithTooFew()
+        {
+            AssertParser.Fails(Character.EqualTo('a').Repeat(3), "aa");
+        }
+
+        [Fact]
+        public void TokenRepeatSucceedsWithNone()
+        {
+            AssertParser.SucceedsWithAll(Token.EqualTo('a').Repeat(0), "");
+        }
+
+        [Fact]
+        public void TokenRepeatSucceedsWithOne()
+        {
+            AssertParser.SucceedsWithAll(Token.EqualTo('a').Repeat(1), "a");
+        }
+
+        [Fact]
+        public void TokenRepeatSucceedsWithTwo()
+        {
+            AssertParser.SucceedsWithAll(Token.EqualTo('a').Repeat(2), "aa");
+        }
+
+        [Fact]
+        public void TokenRepeatFailsWithTooFew()
+        {
+            AssertParser.Fails(Token.EqualTo('a').Repeat(3), "aa");
+        }
+    }
+}


### PR DESCRIPTION
I had a skim through the examples we've got listed in the README, and noticed that the DateTime example had an implementation of `Repeat`, which really belongs in the core library.

The example was a little cluttered with the inclusion of optional `"` double quotes as well as supporting time-only `DateTime`s,, so I've removed those features and hopefully boiled it down to a few core combinators. It's not an optimal implementation, since it should be possible to parse ISO-8601 without allocating, but as an introduction to Superpower it's useful.