### PR TITLE
Annotated JSON parser example

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ Superpower is introduced, with a worked example, in [this blog post](https://nbl
 
 **Example** parsers to learn from:
 
+* [_JsonParser_](https://github.com/datalust/superpower/tree/dev/sample/JsonParser/Program.cs) is a complete, annotated
+ example implementing the [JSON spec](https://json.org) with good error reporting
 * [_DateTimeTextParser_](https://github.com/datalust/superpower/tree/dev/sample/DateTimeTextParser) shows how Superpower's text parsers work, parsing ISO-8601 date-times
 * [_IntCalc_](https://github.com/datalust/superpower/tree/dev/sample/IntCalc) is a simple arithmetic expresion parser (`1 + 2 * 3`) included in the repository, demonstrating how Superpower token parsing works
 * [_Plotty_](https://github.com/SuperJMN/Plotty) implements an instruction set for a RISC virtual machine

--- a/Superpower.sln
+++ b/Superpower.sln
@@ -43,6 +43,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntCalc", "sample\IntCalc\I
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DateTimeParser", "sample\DateTimeTextParser\DateTimeParser.csproj", "{A842DA99-4EAB-423D-B532-7902FED0D8F1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JsonParser", "sample\JsonParser\JsonParser.csproj", "{5C9AB721-559A-4617-B990-2D9EE85BEB7C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,10 @@ Global
 		{A842DA99-4EAB-423D-B532-7902FED0D8F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A842DA99-4EAB-423D-B532-7902FED0D8F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A842DA99-4EAB-423D-B532-7902FED0D8F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5C9AB721-559A-4617-B990-2D9EE85BEB7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5C9AB721-559A-4617-B990-2D9EE85BEB7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5C9AB721-559A-4617-B990-2D9EE85BEB7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C9AB721-559A-4617-B990-2D9EE85BEB7C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -79,6 +85,7 @@ Global
 		{1A9C8D7E-4DFC-48CD-99B0-63612197E95F} = {2ED926D3-7AC8-4BFD-A16B-74D942602968}
 		{34BBD428-8297-484E-B771-0B72C172C264} = {7533E145-1C93-4348-A70D-E68746C5438C}
 		{A842DA99-4EAB-423D-B532-7902FED0D8F1} = {7533E145-1C93-4348-A70D-E68746C5438C}
+		{5C9AB721-559A-4617-B990-2D9EE85BEB7C} = {7533E145-1C93-4348-A70D-E68746C5438C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F3941419-6499-4871-BEAA-861F4FE5D2D4}

--- a/sample/JsonParser/JsonParser.csproj
+++ b/sample/JsonParser/JsonParser.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="../../src/Superpower/Superpower.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sample/JsonParser/Program.cs
+++ b/sample/JsonParser/Program.cs
@@ -82,7 +82,9 @@ namespace JsonParser
                         .Or(Character.EqualTo('r').Value('\r'))
                         .Or(Character.EqualTo('t').Value('\t'))
                         .Or(Character.EqualTo('u').IgnoreThen(
-                                Span.Length(4).Apply(Numerics.HexDigitsUInt32).Select(cc => (char)cc)))
+                                Span.MatchedBy(Character.HexDigit.Repeat(4))
+                                    .Apply(Numerics.HexDigitsUInt32)
+                                    .Select(cc => (char)cc)))
                         .Named("escape sequence")))                
                 .Many()
             from close in Character.EqualTo('"')

--- a/sample/JsonParser/Program.cs
+++ b/sample/JsonParser/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Superpower;
+using Superpower.Display;
 using Superpower.Model;
 using Superpower.Parsers;
 using Superpower.Tokenizers;
@@ -9,14 +10,28 @@ namespace JsonParser
 {
     enum JsonToken
     {
+        [Token(Example = "{")]
         LBracket,
+
+        [Token(Example = "}")]
         RBracket,
+        
+        [Token(Example = "[")]
         LSquareBracket,
+        
+        [Token(Example = "]")]
         RSquareBracket,
+        
+        [Token(Example = ":")]
         Colon,
+        
+        [Token(Example = ",")]
         Comma,
+        
         String,
+        
         Number,
+        
         Identifier,
     }
 
@@ -78,7 +93,7 @@ namespace JsonParser
             from whole in Numerics.Natural.Select(n => double.Parse(n.ToStringValue()))
             from frac in Character.EqualTo('.')
                 .IgnoreThen(Numerics.Natural)
-                .Select(n => double.Parse("0." + n.ToStringValue()))
+                .Select(n => double.Parse(n.ToStringValue()) * Math.Pow(10, -n.Length))
                 .OptionalOrDefault()
             from exp in Character.EqualToIgnoreCase('e')
                 .IgnoreThen(Character.EqualTo('+').Value(1.0)
@@ -170,11 +185,14 @@ namespace JsonParser
             var line = Console.ReadLine();
             while (line != null)
             {
-                Console.WriteLine("Parsing");
-                if (JsonParser.TryParse(line, out var value, out var error))
-                    Console.WriteLine("Parsed: " + (value ?? "<null>"));
-                else
-                    Console.WriteLine("Error: " + error);
+                if (!string.IsNullOrWhiteSpace(line))
+                {
+                    Console.WriteLine("Parsing");
+                    if (JsonParser.TryParse(line, out var value, out var error))
+                        Console.WriteLine("Parsed: " + (value ?? "<null>"));
+                    else
+                        Console.WriteLine("Error: " + error);
+                }
 
                 line = Console.ReadLine();
             }

--- a/sample/JsonParser/Program.cs
+++ b/sample/JsonParser/Program.cs
@@ -343,7 +343,6 @@ namespace JsonParser
                     }
                 }
 
-                Console.Write("json> ");
                 line = Console.ReadLine();
             }
         }

--- a/sample/JsonParser/Program.cs
+++ b/sample/JsonParser/Program.cs
@@ -327,6 +327,7 @@ namespace JsonParser
     {
         static void Main()
         {
+            Console.Write("json> ");
             var line = Console.ReadLine();
             while (line != null)
             {
@@ -342,6 +343,7 @@ namespace JsonParser
                     }
                 }
 
+                Console.Write("json> ");
                 line = Console.ReadLine();
             }
         }

--- a/sample/JsonParser/Program.cs
+++ b/sample/JsonParser/Program.cs
@@ -19,7 +19,7 @@ namespace JsonParser
 {
     // The parser is token-based. This enum lists the various kinds
     // of element that make up a JSON document. Check out the
-    // the JSON spec linked above: you'll see that the tokens kinds map very
+    // the JSON spec linked above: you'll see that the token kinds map very
     // closely to what you see in the boxes of the syntax diagrams.
     enum JsonToken
     {
@@ -62,8 +62,8 @@ namespace JsonParser
         // concept that groups `true`, `false`, and `null`, it's useful
         // for the tokenizer to be very permissive - it's more informative
         // to generate an error later at the parsing stage, e.g.
-        // _unexpected identifier `flase`_, instead of failing at the
-        // tokenization stage where all we'd have is _unexpected `l`_.
+        // "unexpected identifier `flase`", instead of failing at the
+        // tokenization stage where all we'd have is "unexpected `l`".
         Identifier,
     }
 

--- a/sample/JsonParser/Program.cs
+++ b/sample/JsonParser/Program.cs
@@ -334,7 +334,6 @@ namespace JsonParser
                 {
                     if (JsonParser.TryParse(line, out var value, out var error))
                     {
-                        Console.WriteLine("Success:");
                         Print(value);
                     }
                     else

--- a/sample/JsonParser/Program.cs
+++ b/sample/JsonParser/Program.cs
@@ -6,16 +6,42 @@ using Superpower.Model;
 using Superpower.Parsers;
 using Superpower.Tokenizers;
 
+// This is an example JSON parser. It correctly and completely implements the
+// language spec at https://json.org (or should), but the goal isn't to use
+// this "for real" - there are no tests, after all! :-)
+//
+// The goal of the example is to demonstrate how a reasonably-efficient parser
+// with end-user-quality error reporting can be built using Superpower. Getting
+// everything "just perfect" does take some fine tuning, but the result is still
+// readable.
+
 namespace JsonParser
 {
+    // The parser is token-based. This enum lists the various kinds
+    // of element that make up a JSON document. Check out the
+    // the JSON spec linked above: you'll see that the tokens kinds map very
+    // closely to what you see in the boxes of the syntax diagrams.
     enum JsonToken
     {
+        // In general, it's better to be more, rather than less-specific
+        // when it comes to choosing what kinds of tokens to generate,
+        // because conditional rules in the parser - like "match this
+        // kind of token" - can be written more simply if the tokens are
+        // descriptive.
         [Token(Example = "{")]
         LBracket,
 
+        // The `Token` attribute lets a little more information be
+        // associated with the token. In error messages, the token will
+        // normally be described by lower-casing the enum variant name:
+        // "unexpected rbracket" - the `Example` property will turn this
+        // into "unexpected `}`".
         [Token(Example = "}")]
         RBracket,
         
+        // Notice that the tokens describe the characters and clumps of
+        // characters in the language - it's a "bracket", at this level, not
+        // an "array start".
         [Token(Example = "[")]
         LSquareBracket,
         
@@ -32,11 +58,45 @@ namespace JsonParser
         
         Number,
         
+        // Although JSON doesn't have an "identifier" or "keyword"
+        // concept that groups `true`, `false`, and `null`, it's useful
+        // for the tokenizer to be very permissive - it's more informative
+        // to generate an error later at the parsing stage, e.g.
+        // _unexpected identifier `flase`_, instead of failing at the
+        // tokenization stage where all we'd have is _unexpected `l`_.
         Identifier,
     }
 
+    // The tokenizer here is assembled using `TokenizerBuilder`. The `Instance`
+    // property is the place to start reading, but it has to be ordered below
+    // the two "recognizers" that it depends upon, or else they'll be uninitialized
+    // when we try to put the tokenizer together.
     static class JsonTokenizer
     {
+        // This is a "recognizer" that matches - just like a regular expression would -
+        // a block of input text that resembles a JSON string. Notice that it's very
+        // permissive - it's only concerned with finding the start and end of the string,
+        // and doesn't try verifying the correctness of escape sequences and so-on.
+        //
+        // The `Unit` type is just a way of expressing `Void` in a C#-friendly way: the
+        // recognizer doesn't need to return a value, just match the text.
+        //
+        // The parser uses built-ins like `Character.EqualTo()` and `Span.EqualTo()`.
+        // There's a whole range of simple parsers like these in the `Parsers` namespace.
+        //
+        // Also in here, you encounter a couple of Superpower's less-obvious combinators:
+        //
+        //  * `Try()` causes the attempted match of `\"` to backtrack; in order to report
+        //    errors accurately, Superpower fails fast when a parser partially matches its
+        //    input, as `Span.EqualTo("\\\"")` will when it finds other escape sequences
+        //    such as `\n`. When we backtrack, we can try parsing the `\` again with the
+        //    following `Character.Except('"')` parser.
+        //  * `Value()` here is just being used cast the span parser and the character
+        //    parser to compatible types (since we don't care about the values matched
+        //    by either of them.
+        //  * `IgnoreMany()` is an optimization - we could have used `Many()` here, only
+        //    that would allocate an array to return its value - `IgnoreMany()` just
+        //    drops the items that it matches.
         static TextParser<Unit> JsonStringToken { get; } =
             from open in Character.EqualTo('"')
             from content in Span.EqualTo("\\\"").Value(Unit.Value).Try()
@@ -45,12 +105,31 @@ namespace JsonParser
             from close in Character.EqualTo('"')
             select Unit.Value;
 
+        // Like the string parser, the number version is permissive - it's just looking 
+        // for a chunk of input that looks something like a JSON number, and not
+        // necessarily a valid one.
         static TextParser<Unit> JsonNumberToken { get; } =
             from sign in Character.EqualTo('-').OptionalOrDefault()
             from first in Character.Digit
             from rest in Character.Digit.Or(Character.In('.', 'e', 'E', '+', '-')).IgnoreMany()
             select Unit.Value;
 
+        // Here's the tokenizer. Working through the input text, the rules are
+        // tried in top-to-bottom order until one of them matches. When a rule
+        // matches, that rule's token will be produced, and then the tokenizer
+        // starts again with the remaining input.
+        //
+        // The number and identifier tokens are marked as requiring delimiters
+        // (all of the other tokens/whitespace are implicitly considered to
+        // be delimiters), so that, say, "123abc" isn't inadvertently tokenized
+        // as a number, "123", followed by the identifier "abc". The `requireDelimiters`
+        // flag deals with this case.
+        //
+        // One important note about the tokenizer - it's not the place to detect or report
+        // errors, except when it's unavoidable. Better errors can be generated later
+        // in the parsing process. That's why we accept anything that looks remotely
+        // like an identifier, and only check during parsing whether it's a
+        // `true`, `false`, `null`, or some invalid junk.
         public static Tokenizer<JsonToken> Instance { get; } = 
             new TokenizerBuilder<JsonToken>()
                 .Ignore(Span.WhiteSpace)
@@ -66,8 +145,45 @@ namespace JsonParser
                 .Build();
     }
 
+    // By this point, we have everything we need to break a JSON document down
+    // into a stream of tokens resembling `[LBracket, String("foo"), Colon, ...]`.
+    //
+    // From this point there are actually two jobs remaining to do.
+    // 
+    // We'll need to assemble the structure of the JSON document, with arrays,
+    // objects, and so-on, and we'll also have to decode strings and
+    // numbers into their .NET representations - `string`s and `double`s.
+    //
+    // Before we assemble the document, we'll jump to the latter task: the
+    // `JsonTextParsers` class contains two standalone character-driven parsers
+    // that can handle the (non-trivial) string and number formats from
+    // the JSON spec.
     static class JsonTextParsers
     {
+        // Text parsers like these use the same `TextParser<T>` type that the
+        // recognizers in the tokenizer use. This might get a little confusing,
+        // but it's also rather handy: these parsers could just as easily do
+        // double duty as recognizers in the tokenizer - we don't do that here
+        // because we want the tokenizer to be more permissive (and there's
+        // some redundant work done for things like decoding escape
+        // sequences and allocating the .NET `string` object that the tokenizer
+        // can avoid).
+        //
+        // Most of the parsers and combinators here are self-explanatory, but
+        // we also encounter a `Span` parser being used in conjunction with
+        // `Apply()` to glue together some pre-built parsers to deal with the
+        // four-character unicode character code escape (like "\u0056"). This part
+        // could be written a few different ways, along the lines of:
+        //
+        // `Character.HexDigit.Repeat(4).Select(chs => (char)int.Parse(new string(chs), ...`
+        //
+        // In general, using Superpower parsers over methods like `int.Parse()` will
+        // be less likely to throw exceptions, and should report better error info
+        // just in case some invalid input slips through.
+        //
+        // `Named()` is used here to insert text into "expectations"; rather than
+        // reporting "expected `\`, `"`, `/`, `b`, f`.." etc., the error message
+        // generated for an invalid escape sequence reads "expected escape sequence".
         public static TextParser<string> String { get; } =
             from open in Character.EqualTo('"')
             from chars in Character.ExceptIn('"', '\\')
@@ -90,6 +206,10 @@ namespace JsonParser
             from close in Character.EqualTo('"')
             select new string(chars);
 
+        // The number parser here works with some pretty ugly `double`-based
+        // maths; it's tricky enough that in a real-world parser, it would
+        // be worth considering some imperative code to do this (see the way
+        // that `Numerics.NaturalInt32` and similar parsers work, for examples).
         public static TextParser<double> Number { get; } =
             from sign in Character.EqualTo('-').Value(-1.0).OptionalOrDefault(1.0)
             from whole in Numerics.Natural.Select(n => double.Parse(n.ToStringValue()))
@@ -106,8 +226,17 @@ namespace JsonParser
             select (whole + frac) * sign * Math.Pow(10, exp);
     }
 
+    // Here we are at the meat of the parser! You already know, from the
+    // sections above, just about everything required to completely understand
+    // this one.
     static class JsonParser
     {
+        // For simplicity, we use `object` as the stand-in for every
+        // possible JSON value type. There's quite a lot of casting:
+        // unfortunately, for performance reasons, Superpower uses a
+        // parser design that doesn't allow for variance, so you need
+        // to create a parser that returns `object` here, even though
+        // one that returns `string` should, in theory, be compatible.
         static TokenListParser<JsonToken, object> JsonString { get; } =
             Token.EqualTo(JsonToken.String)
                 .Apply(JsonTextParsers.String)
@@ -118,6 +247,11 @@ namespace JsonParser
                 .Apply(JsonTextParsers.Number)
                 .Select(n => (object)n);
 
+        // The grammar is recursive - values can be objects, which contain
+        // values, which can be objects... In order to reflect this circularity,
+        // the parser below uses `Parse.Ref()` to refer lazily to the `JsonValue`
+        // parser, which won't be constructed until after the runtime initializes
+        // the `JsonObject` parser.
         static TokenListParser<JsonToken, object> JsonObject { get; } =
             from open in Token.EqualTo(JsonToken.LBracket)
             from properties in JsonString
@@ -156,6 +290,10 @@ namespace JsonParser
 
         static TokenListParser<JsonToken, object> JsonDocument { get; } = JsonValue.AtEnd();
 
+        // `TryParse` is just a helper method. It's useful to write one of these, where
+        // the tokenization and parsing phases remain distinct, because it's often very
+        // handy to place a breakpoint between the two steps to check out what the
+        // token list looks like.
         public static bool TryParse(string json, out object value, out string error)
         {
             var tokens = JsonTokenizer.Instance.TryTokenize(json);
@@ -180,6 +318,11 @@ namespace JsonParser
         }
     }
 
+    // The driver program accepts a JSON value (string, number, array, object...)
+    // on each line and prints the result of parsing, or an error message.
+    // Try typing in some valid and some malformed input! The error messages should
+    // always be informative; if you find a case where they're not, please raise
+    // an issue :).
     static class Program
     {
         static void Main()
@@ -189,15 +332,61 @@ namespace JsonParser
             {
                 if (!string.IsNullOrWhiteSpace(line))
                 {
-                    Console.WriteLine("Parsing");
                     if (JsonParser.TryParse(line, out var value, out var error))
-                        Console.WriteLine("Parsed: " + (value ?? "<null>"));
+                    {
+                        Console.WriteLine("Success:");
+                        Print(value);
+                    }
                     else
+                    {
                         Console.WriteLine("Error: " + error);
+                    }
                 }
 
                 line = Console.ReadLine();
             }
+        }
+
+        static void Print(object value, int indent = 0)
+        {
+            switch (value)
+            {
+                case null:
+                    Indent(indent, "Null");
+                    break;
+                case true:
+                    Indent(indent, "True");
+                    break;
+                case false:
+                    Indent(indent, "False");
+                    break;
+                case double n:
+                    Indent(indent, $"Number: {n}");
+                    break;
+                case string s:
+                    Indent(indent, $"String: {s}");
+                    break;
+                case object[] a:
+                    Indent(indent, "Array:");
+                    foreach (var el in a)
+                        Print(el, indent + 2);
+                    break;
+                case Dictionary<string, object> o:
+                    Indent(indent, "Object:");
+                    foreach (var p in o)
+                    {
+                        Indent(indent + 2, p.Key);
+                        Print(p.Value, indent + 4);
+                    }
+                    break;
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        static void Indent(int amount, string text)
+        {
+            Console.WriteLine($"{new string(' ', amount)}{text}");
         }
     }
 }

--- a/sample/JsonParser/Program.cs
+++ b/sample/JsonParser/Program.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using Superpower;
+using Superpower.Parsers;
+using Superpower.Tokenizers;
+
+namespace JsonParser
+{
+    enum JsonToken
+    {
+        LBracket,
+        RBracket,
+        LSquareBracket,
+        RSquareBracket,
+        Colon,
+        Comma,
+        String,
+        Number,
+        True,
+        False,
+        Null,
+    }
+
+    static class JsonTextParsers
+    {
+        public static TextParser<string> String { get; } =
+            from _ in Character.EqualTo('"')
+            from chars in Character.Except('\\').Try()
+                .Or(Character.EqualTo('\\')
+                    .IgnoreThen(Character.EqualTo('\\')
+                        .Or(Character.EqualTo('"').Value('"'))
+                        .Or(Character.EqualTo('/').Value('/'))
+                        .Or(Character.EqualTo('b').Value('\b'))
+                        .Or(Character.EqualTo('f').Value('\f'))
+                        .Or(Character.EqualTo('n').Value('\n'))
+                        .Or(Character.EqualTo('r').Value('\r'))
+                        .Or(Character.EqualTo('t').Value('\t'))
+                        .Or(Span.Length(4).Apply(Numerics.HexUInt32).Select(cc => (char)cc))))                
+                .Many()
+            from __ in Character.EqualTo('"')
+            select new string(chars);
+
+        public static TextParser<double> Number { get; } =
+            from sign in Character.EqualTo('-').Value(-1.0).OptionalOrDefault(1.0)
+            from whole in Numerics.Natural.Select(n => double.Parse(n.ToStringValue()))
+            from frac in Character.EqualTo('.')
+                .IgnoreThen(Numerics.Natural)
+                .Select(n => double.Parse("0." + n.ToStringValue()))
+                .OptionalOrDefault()
+            from exp in Character.EqualToIgnoreCase('e')
+                .IgnoreThen(Character.EqualTo('+').Value(1.0)
+                    .Or(Character.EqualTo('-').Value(-1.0))
+                    .OptionalOrDefault(1.0))
+                .Then(expsign => Numerics.Natural.Select(n => double.Parse(n.ToStringValue()) * expsign))
+            select (whole + frac) * sign * Math.Pow(10, exp);
+    }
+
+    static class JsonTokenizer
+    {
+        public static Tokenizer<JsonToken> Instance { get; } = Create();
+
+        static Tokenizer<JsonToken> Create()
+        {
+            return new TokenizerBuilder<JsonToken>()
+                .Ignore(Span.WhiteSpace)
+                .Match(Character.EqualTo('{'), JsonToken.LBracket)
+                .Match(Character.EqualTo('}'), JsonToken.RBracket)
+                .Match(Character.EqualTo(':'), JsonToken.Colon)
+                .Match(Character.EqualTo(','), JsonToken.Comma)
+                .Match(Character.EqualTo('['), JsonToken.LSquareBracket)
+                .Match(Character.EqualTo(']'), JsonToken.RSquareBracket)
+                .Match(JsonTextParsers.String, JsonToken.String)
+                .Match(JsonTextParsers.Number, JsonToken.Number)
+                .Match(Span.EqualTo("true"),   JsonToken.True)
+                .Match(Span.EqualTo("false"),  JsonToken.False)
+                .Match(Span.EqualTo("null"),   JsonToken.Null)
+                .Build();
+        }
+    }
+
+    static class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/src/Superpower/Combinators.cs
+++ b/src/Superpower/Combinators.cs
@@ -102,6 +102,9 @@ namespace Superpower
                     return Result.CastEmpty<TextSpan, U>(rt);
 
                 var uResult = valueParserAtEnd(rt.Value);
+                if (!uResult.HasValue)
+                    return uResult;
+                
                 return Result.Value(uResult.Value, rt.Location, rt.Remainder);
             };
         }

--- a/src/Superpower/Combinators.cs
+++ b/src/Superpower/Combinators.cs
@@ -101,7 +101,8 @@ namespace Superpower
                 if (!rt.HasValue)
                     return Result.CastEmpty<TextSpan, U>(rt);
 
-                return valueParserAtEnd(rt.Value);
+                var uResult = valueParserAtEnd(rt.Value);
+                return Result.Value(uResult.Value, rt.Location, rt.Remainder);
             };
         }
 

--- a/src/Superpower/Parsers/Character.cs
+++ b/src/Superpower/Parsers/Character.cs
@@ -144,6 +144,11 @@ namespace Superpower.Parsers
         /// Parse a numeric character.
         /// </summary>
         public static TextParser<char> Numeric { get; } = Matching(char.IsNumber, "numeric character");
+
+        /// <summary>
+        /// Parse a hexadecimal digit (0-9, a-f, A-F).
+        /// </summary>
+        public static TextParser<char> HexDigit { get; } = Matching(CharInfo.IsHexDigit, "hex digit");
     }
 }
 

--- a/src/Superpower/Parsers/Numerics.cs
+++ b/src/Superpower/Parsers/Numerics.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Superpower.Model;
+using Superpower.Util;
 
 namespace Superpower.Parsers
 {
@@ -204,29 +205,11 @@ namespace Superpower.Parsers
                 .Then(n => Character.EqualTo('.').IgnoreThen(Natural).OptionalOrDefault()
                     .Select(f => f == TextSpan.None ? n : new TextSpan(n.Source, n.Position, n.Length + f.Length + 1)));
 
-        static bool IsHexDigit(char ch)
-        {
-            return char.IsDigit(ch) || ch >= 'a' && ch <= 'f' || ch >= 'A' && ch <= 'F';
-        }
-
-        static int HexValue(char ch)
-        {
-            if (char.IsDigit(ch))
-                return ch - '0';
-
-            if (ch >= 'a' && ch <= 'f')
-                return 15 + ch - 'f';
-
-            return 15 + ch - 'F';
-        }
-
-        static TextParser<char> HexDigit { get; } = Character.Matching(IsHexDigit, "hex digit");
-
         /// <summary>
         /// Matches hexadecimal numbers.
         /// </summary>
         public static TextParser<TextSpan> HexDigits { get; } =
-            Span.MatchedBy(HexDigit.AtLeastOnce());  
+            Span.MatchedBy(Character.HexDigit.AtLeastOnce());  
         
         /// <summary>
         /// A string of hexadecimal digits, converted into a <see cref="uint"/>.
@@ -235,17 +218,17 @@ namespace Superpower.Parsers
         {
             var next = input.ConsumeChar();
             
-            if (!next.HasValue || !IsHexDigit(next.Value))
+            if (!next.HasValue || !CharInfo.IsHexDigit(next.Value))
                 return Result.Empty<uint>(input, ExpectedHexDigit);
 
             TextSpan remainder;
             var val = 0u;
             do
             {
-                val = 16 * val + (uint)HexValue(next.Value);
+                val = 16 * val + (uint)CharInfo.HexValue(next.Value);
                 remainder = next.Remainder;
                 next = remainder.ConsumeChar();
-            } while (next.HasValue && IsHexDigit(next.Value));
+            } while (next.HasValue && CharInfo.IsHexDigit(next.Value));
             
             return Result.Value(val, input, remainder);
         };
@@ -257,17 +240,17 @@ namespace Superpower.Parsers
         {
             var next = input.ConsumeChar();
             
-            if (!next.HasValue || !IsHexDigit(next.Value))
+            if (!next.HasValue || !CharInfo.IsHexDigit(next.Value))
                 return Result.Empty<ulong>(input, ExpectedHexDigit);
 
             TextSpan remainder;
             var val = 0ul;
             do
             {
-                val = 16 * val + (ulong)HexValue(next.Value);
+                val = 16 * val + (ulong)CharInfo.HexValue(next.Value);
                 remainder = next.Remainder;
                 next = remainder.ConsumeChar();
-            } while (next.HasValue && IsHexDigit(next.Value));
+            } while (next.HasValue && CharInfo.IsHexDigit(next.Value));
             
             return Result.Value(val, input, remainder);
         };

--- a/src/Superpower/Tokenizers/TokenizerBuilder.cs
+++ b/src/Superpower/Tokenizers/TokenizerBuilder.cs
@@ -177,7 +177,7 @@ namespace Superpower.Tokenizers
                         // We know the token's kind here, so might as well included it so that we can yield more
                         // detailed messages.
                         var augmentedMessage = $"invalid {Presentation.FormatExpectation(recognizer.Kind)}, {attempt.FormatErrorMessageFragment()}";
-                        failure = new Result<TKind>(attempt.Remainder, augmentedMessage, attempt.Expectations, attempt.Backtrack);
+                        failure = new Result<TKind>(remainder, augmentedMessage, attempt.Expectations, attempt.Backtrack);
                     }
                 }
 

--- a/src/Superpower/Tokenizers/TokenizerBuilder.cs
+++ b/src/Superpower/Tokenizers/TokenizerBuilder.cs
@@ -175,8 +175,14 @@ namespace Superpower.Tokenizers
                         attempt.ErrorPosition.Absolute > failure.ErrorPosition.Absolute)
                     {
                         // We know the token's kind here, so might as well included it so that we can yield more
-                        // detailed messages.
+                        // detailed messages. Reporting the failure position as the token's start position makes it
+                        // much more sensible to refer to the token by kind, and easier to figure out what's going on
+                        // in cases like missing closing delimiters (which end pulling the whole remainder into the
+                        // token). Including the actual failure position in the error message helps to further pinpoint
+                        // the problem.
                         var augmentedMessage = $"invalid {Presentation.FormatExpectation(recognizer.Kind)}, {attempt.FormatErrorMessageFragment()}";
+                        if (!attempt.Remainder.IsAtEnd)
+                            augmentedMessage += $" at line {attempt.Remainder.Position.Line}, column {attempt.Remainder.Position.Column}";
                         failure = new Result<TKind>(remainder, augmentedMessage, attempt.Expectations, attempt.Backtrack);
                     }
                 }

--- a/src/Superpower/Util/CharInfo.cs
+++ b/src/Superpower/Util/CharInfo.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2018 Datalust, Superpower Contributors, Sprache Contributors
+//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  
+//
+//     http://www.apache.org/licenses/LICENSE-2.0  
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Superpower.Util
+{
+    static class CharInfo
+    {
+        public static bool IsHexDigit(char ch)
+        {
+            return char.IsDigit(ch) || ch >= 'a' && ch <= 'f' || ch >= 'A' && ch <= 'F';
+        }
+
+        public static int HexValue(char ch)
+        {
+            if (char.IsDigit(ch))
+                return ch - '0';
+
+            if (ch >= 'a' && ch <= 'f')
+                return 15 + ch - 'f';
+
+            return 15 + ch - 'F';
+        }
+    }
+}

--- a/test/Superpower.Tests/Parsers/SpanTests.cs
+++ b/test/Superpower.Tests/Parsers/SpanTests.cs
@@ -70,7 +70,7 @@ namespace Superpower.Tests.Parsers
             var parser = Span.MatchedBy(Numerics.IntegerInt32);
             var input = new TextSpan("123abc");
             var r = parser(input);
-            Assert.Equal(r.Value.ToStringValue(), "123");
+            Assert.Equal("123", r.Value.ToStringValue());
         }
     }
 }

--- a/test/Superpower.Tests/Tokenizers/TokenizerBuilderTests.cs
+++ b/test/Superpower.Tests/Tokenizers/TokenizerBuilderTests.cs
@@ -52,7 +52,22 @@ namespace Superpower.Tests.Tokenizers
             var tokens = tokenizer.TryTokenize(" abd");
             Assert.False(tokens.HasValue);
             var msg = tokens.ToString();
-            Assert.Equal("Syntax error (line 1, column 4): invalid abc, unexpected `d`, expected `c`.", msg);
+            Assert.Equal("Syntax error (line 1, column 2): invalid abc, unexpected `d`, expected `c` at line 1, column 4.", msg);
+        }
+
+        [Fact]
+        public void ShortTokenizationIsReported()
+        {
+            var tokenizer = new TokenizerBuilder<string>()
+                .Ignore(Span.WhiteSpace)
+                .Match(Span.EqualTo("abc"), "abc")
+                .Match(Span.EqualTo("def"), "def")
+                .Build();
+
+            var tokens = tokenizer.TryTokenize(" ab");
+            Assert.False(tokens.HasValue);
+            var msg = tokens.ToString();
+            Assert.Equal("Syntax error (line 1, column 2): invalid abc, unexpected end of input, expected `c`.", msg);
         }
     }
 }


### PR DESCRIPTION
We're a bit overdue for a more complete example, I've put together one that parses JSON (a familiar format), while focusing on good error reporting.

It's a runnable program:

```
json> {"foo": [1, 2, {"bar": }]}
Error: Syntax error (line 1, column 24): unexpected `}`, expected JSON value.

json> {"foo": [1, 2, {"bar": 42}]}
Object:
  foo
    Array:
      Number: 1
      Number: 2
      Object:
        bar
          Number: 42
```

The whole thing's inline in one long, verbosely-commented `Program.cs` that I've linked from the README.

Was a good opportunity to shake out some small bugs in the process :-)