### PR TITLE
Correctly detect failed Apply() parsers

### DIFF
--- a/sample/JsonParser/Program.cs
+++ b/sample/JsonParser/Program.cs
@@ -294,13 +294,14 @@ namespace JsonParser
         // the tokenization and parsing phases remain distinct, because it's often very
         // handy to place a breakpoint between the two steps to check out what the
         // token list looks like.
-        public static bool TryParse(string json, out object value, out string error)
+        public static bool TryParse(string json, out object value, out string error, out Position errorPosition)
         {
             var tokens = JsonTokenizer.Instance.TryTokenize(json);
             if (!tokens.HasValue)
             {
                 value = null;
                 error = tokens.ToString();
+                errorPosition = tokens.ErrorPosition;
                 return false;
             }
 
@@ -309,11 +310,13 @@ namespace JsonParser
             {
                 value = null;
                 error = parsed.ToString();
+                errorPosition = parsed.ErrorPosition;
                 return false;
             }
 
             value = parsed.Value;
             error = null;
+            errorPosition = Position.Empty;
             return true;
         }
     }
@@ -333,16 +336,18 @@ namespace JsonParser
             {
                 if (!string.IsNullOrWhiteSpace(line))
                 {
-                    if (JsonParser.TryParse(line, out var value, out var error))
+                    if (JsonParser.TryParse(line, out var value, out var error, out var errorPosition))
                     {
                         Print(value);
                     }
                     else
                     {
+                        Console.WriteLine($"     {new string(' ', errorPosition.Column)}^");   
                         Console.WriteLine("Error: " + error);
                     }
                 }
 
+                Console.Write("json> ");
                 line = Console.ReadLine();
             }
         }

--- a/src/Superpower/Model/Result`1.cs
+++ b/src/Superpower/Model/Result`1.cs
@@ -26,12 +26,13 @@ namespace Superpower.Model
         readonly T _value;
 
         /// <summary>
-        /// The location in the stream where the parsing began (== the input).
+        /// If the result is a value, the location in the input corresponding to the
+        /// value. If the result is an error, it's the location of the error.
         /// </summary>
         public TextSpan Location { get; }
 
         /// <summary>
-        /// The first un-parsed location in the stream.
+        /// The first un-parsed location in the input.
         /// </summary>
         public TextSpan Remainder { get; }
 
@@ -41,10 +42,9 @@ namespace Superpower.Model
         public bool HasValue { get; }
 
         /// <summary>
-        /// The position of the first un-parsed location.
+        /// If the result is an error, the source-level position of the error; otherwise, <see cref="Position.Empty"/>.
         /// </summary>
-        // ReSharper disable once UnusedMember.Global
-        public Position ErrorPosition => Remainder.Position;
+        public Position ErrorPosition => HasValue ? Position.Empty : Location.Position;
 
         /// <summary>
         /// A provided error message, or null.
@@ -84,6 +84,17 @@ namespace Superpower.Model
             Backtrack = backtrack;
         }
 
+        internal Result(TextSpan location, TextSpan remainder, string errorMessage, string[] expectations, bool backtrack)
+        {
+            Location = location;
+            Remainder = remainder;
+            _value = default(T);
+            HasValue = false;
+            Expectations = expectations;
+            ErrorMessage = errorMessage;
+            Backtrack = backtrack;
+        }
+
         internal Result(TextSpan remainder, string errorMessage, string[] expectations, bool backtrack)
         {
             Location = Remainder = remainder;
@@ -105,9 +116,9 @@ namespace Superpower.Model
 
             var message = FormatErrorMessageFragment();
             var location = "";
-            if (!Remainder.IsAtEnd)
+            if (!Location.IsAtEnd)
             {
-                location = $" (line {Remainder.Position.Line}, column {Remainder.Position.Column})";
+                location = $" (line {Location.Position.Line}, column {Location.Position.Column})";
             }
 
             return $"Syntax error{location}: {message}.";
@@ -123,13 +134,13 @@ namespace Superpower.Model
                 return ErrorMessage;
             
             string message;
-            if (Remainder.IsAtEnd)
+            if (Location.IsAtEnd)
             {
                 message = "unexpected end of input";
             }
             else
             {
-                var next = Remainder.ConsumeChar().Value;
+                var next = Location.ConsumeChar().Value;
                 message = $"unexpected `{next}`";
             }
 

--- a/src/Superpower/Model/TokenListParserResult.cs
+++ b/src/Superpower/Model/TokenListParserResult.cs
@@ -113,7 +113,7 @@ namespace Superpower.Model
         /// <returns>The converted result.</returns>
         public static TokenListParserResult<TKind,U> CastEmpty<TKind, T, U>(TokenListParserResult<TKind, T> result)
         {
-            return new TokenListParserResult<TKind, U>(result.Remainder, result.ErrorPosition, result.ErrorMessage, result.Expectations, result.Backtrack);
+            return new TokenListParserResult<TKind, U>(result.Remainder, result.SubTokenErrorPosition, result.ErrorMessage, result.Expectations, result.Backtrack);
         }
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace Superpower.Model
                     expectations[i] = second.Expectations[j];
             }
 
-            return new TokenListParserResult<TKind, T>(second.Remainder, second.ErrorPosition, first.ErrorMessage, expectations, second.Backtrack);
+            return new TokenListParserResult<TKind, T>(second.Remainder, second.SubTokenErrorPosition, first.ErrorMessage, expectations, second.Backtrack);
         }
     }
 }

--- a/src/Superpower/Model/TokenList`1.cs
+++ b/src/Superpower/Model/TokenList`1.cs
@@ -158,9 +158,25 @@ namespace Superpower.Model
         public override string ToString()
         {
             if (_tokens == null)
-                return "Token stream (empty)";
+                return "Token list (empty)";
 
-            return "Token stream";
+            return "Token list";
+        }
+
+        // A mildly expensive way to find the "end of input" position for error reporting.
+        internal Position ComputeEndOfInputPosition()
+        {
+            EnsureHasValue();
+            
+            if (_tokens.Length == 0)
+                return Model.Position.Zero;
+
+            var lastSpan = _tokens[_tokens.Length - 1].Span;
+            var source = lastSpan.Source;
+            var position = lastSpan.Position;
+            for (var i = position.Absolute; i < source.Length; ++i)
+                position = position.Advance(source[i]);
+            return position;
         }
     }
 }

--- a/src/Superpower/Tokenizers/TokenizerBuilder.cs
+++ b/src/Superpower/Tokenizers/TokenizerBuilder.cs
@@ -180,7 +180,8 @@ namespace Superpower.Tokenizers
                         // in cases like missing closing delimiters (which end pulling the whole remainder into the
                         // token). Including the actual failure position in the error message helps to further pinpoint
                         // the problem.
-                        var augmentedMessage = $"invalid {Presentation.FormatExpectation(recognizer.Kind)}, {attempt.FormatErrorMessageFragment()}";
+                        var problem = attempt.Remainder.IsAtEnd ? "incomplete" : "invalid";
+                        var augmentedMessage = $"{problem} {Presentation.FormatExpectation(recognizer.Kind)}, {attempt.FormatErrorMessageFragment()}";
                         if (!attempt.Remainder.IsAtEnd)
                             augmentedMessage += $" at line {attempt.Remainder.Position.Line}, column {attempt.Remainder.Position.Column}";
                         failure = new Result<TKind>(remainder, augmentedMessage, attempt.Expectations, attempt.Backtrack);

--- a/test/Superpower.Tests/Tokenizers/TokenizerBuilderTests.cs
+++ b/test/Superpower.Tests/Tokenizers/TokenizerBuilderTests.cs
@@ -67,7 +67,7 @@ namespace Superpower.Tests.Tokenizers
             var tokens = tokenizer.TryTokenize(" ab");
             Assert.False(tokens.HasValue);
             var msg = tokens.ToString();
-            Assert.Equal("Syntax error (line 1, column 2): invalid abc, unexpected end of input, expected `c`.", msg);
+            Assert.Equal("Syntax error (line 1, column 2): incomplete abc, unexpected end of input, expected `c`.", msg);
         }
     }
 }


### PR DESCRIPTION
This fixes #37 and makes a number of small improvements; spinning it up via the JSON example :-)...

![screenshot from 2018-05-30 18-54-44](https://user-images.githubusercontent.com/342712/40710368-cdbc82be-643b-11e8-9000-2951cd940bf5.png)

The number one issue is that `Apply()` should never backtrack if the applied parser fails. Communicating this out to combinators that make these decisions - particularly `Or()` - need to see the `Apply()` parser as having consumed input. This interacts with error location reporting, which makes for some fun juggling of locations, remainders, positions etc.