### PR TITLE
Improved terminated-list error reporting by allowing an alternate end delimiter

### DIFF
--- a/test/Superpower.Tests/Combinators/ManyDelimitedByCombinatorTests.cs
+++ b/test/Superpower.Tests/Combinators/ManyDelimitedByCombinatorTests.cs
@@ -1,0 +1,19 @@
+﻿using Superpower.Parsers;
+using Superpower.Tests.Support;
+using Xunit;
+
+namespace Superpower.Tests.Combinators
+{
+    public class ManyDelimitedByCombinatorTests
+    {
+        [Fact]
+        public void AnEndDelimiterCanBeSpecified()
+        {
+            AssertParser.SucceedsWith(
+                Token.EqualTo('a').Value('a')
+                    .ManyDelimitedBy(Token.EqualTo('b'), end: Token.EqualTo('c')),
+                "ababac",
+                new[] {'a', 'a', 'a'});
+        }
+    }
+}


### PR DESCRIPTION
Thanks for the challenging scenario, @KodrAus :-)

```
json> {x:1}
       ^
Error: Syntax error (line 1, column 2): unexpected identifier `x`, expected property name or `}`.
json> {"x"]
          ^
Error: Syntax error (line 1, column 5): unexpected `]`, expected `:`.
json> {"x":}
           ^
Error: Syntax error (line 1, column 6): unexpected `}`, expected JSON value.
json> {"x":1
            ^
Error: Syntax error: unexpected end of input, expected `}`.
json> {"x":1,}
             ^
Error: Syntax error (line 1, column 8): unexpected `}`, expected property name.
json> {"x":1,foo:2}
             ^
Error: Syntax error (line 1, column 8): unexpected identifier `foo`, expected property name.
json> 
```

The solution to this one was to allow an optional end-delimiter to be passed to `ManyDelimitedBy()`:

```csharp
        static TokenListParser<JsonToken, object> JsonObject { get; } =
            from begin in Token.EqualTo(JsonToken.LBracket)
            from properties in JsonString
                .Named("property name")
                .Then(name => Token.EqualTo(JsonToken.Colon)
                    .IgnoreThen(Parse.Ref(() => JsonValue)
                    .Select(value => KeyValuePair.Create((string)name, value))))    
                .ManyDelimitedBy(Token.EqualTo(JsonToken.Comma),
                    end: Token.EqualTo(JsonToken.RBracket)) // <--- here
            select (object)new Dictionary<string, object>(properties);
```

This does break the symmetry with `begin`, in this parser, but specifying both `begin` and `end` under `ManyDelimitedBy()` would break the preferred left-to-right, top-to-bottom evaluation order. Allowing this would be one possible alternative, however.