### PR TITLE
Add Numerics.DecimalDecimal and DecimalDouble

### DIFF
--- a/sample/JsonParser/test.json
+++ b/sample/JsonParser/test.json
@@ -1,0 +1,22 @@
+{
+  "glossary": {
+    "title": "example glossary",
+    "GlossDiv": {
+      "title": "S",
+      "GlossList": {
+        "GlossEntry": {
+          "ID": "SGML",
+          "SortAs": "SGML",
+          "GlossTerm": "Standard Generalized Markup Language",
+          "Acronym": "SGML",
+          "Abbrev": "ISO 8879:1986",
+          "GlossDef": {
+            "para": "A meta-markup language, used to create markup languages such as DocBook.",
+            "GlossSeeAlso": [ "GML", "XML" ]
+          },
+          "GlossSee": "markup"
+        }
+      }
+    }
+  }
+}

--- a/src/Superpower/Parsers/Numerics.cs
+++ b/src/Superpower/Parsers/Numerics.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Globalization;
 using Superpower.Model;
 using Superpower.Util;
 
@@ -204,6 +205,18 @@ namespace Superpower.Parsers
             Integer
                 .Then(n => Character.EqualTo('.').IgnoreThen(Natural).OptionalOrDefault()
                     .Select(f => f == TextSpan.None ? n : new TextSpan(n.Source, n.Position, n.Length + f.Length + 1)));
+
+        /// <summary>
+        /// Matches decimal numbers, for example <code>-1.23</code>, converted into a <see cref="decimal"/>.
+        /// </summary>
+        public static TextParser<decimal> DecimalDecimal { get; } =
+            Decimal.Select(span => decimal.Parse(span.ToStringValue(), CultureInfo.InvariantCulture));
+
+        /// <summary>
+        /// Matches decimal numbers, for example <code>-1.23</code>, converted into a <see cref="double"/>.
+        /// </summary>
+        public static TextParser<double> DecimalDouble { get; } =
+            Decimal.Select(span => double.Parse(span.ToStringValue(), CultureInfo.InvariantCulture));
 
         /// <summary>
         /// Matches hexadecimal numbers.

--- a/test/Superpower.Tests/Parsers/NumericsTests.cs
+++ b/test/Superpower.Tests/Parsers/NumericsTests.cs
@@ -81,5 +81,19 @@ namespace Superpower.Tests.Parsers
         {
             AssertParser.FitsTheory(Numerics.Decimal, input, isMatch);
         }
+
+        [Fact]
+        public void DecimalNumbersAreParsed()
+        {
+            var parsed = Numerics.DecimalDecimal.Parse("-123.456");
+            Assert.Equal(-123.456m, parsed);
+        }
+
+        [Fact]
+        public void DecimalDoublesAreParsed()
+        {
+            var parsed = Numerics.DecimalDouble.Parse("-123.456");
+            Assert.Equal(-123.456, parsed);
+        }
     }
 }


### PR DESCRIPTION
It's a little inconsistent that the integral parsers in `Numerics` have variants that return C# types; this adds `DecimalDecimal` and `DecimalDouble` (it's a little unfortunate that the BCL's naming between integral types like `UInt32` and decimal/floating-point types like `Double` is a little inconsistent :-))