### PR TITLE
Fix incorrect tokenization when last matcher is delimited

### DIFF
--- a/src/Superpower/Tokenizers/TokenizerBuilder.cs
+++ b/src/Superpower/Tokenizers/TokenizerBuilder.cs
@@ -158,7 +158,7 @@ namespace Superpower.Tokenizers
                     }
                     else
                     {
-                        yield break;
+                        break;
                     }
                 }
 

--- a/test/Superpower.Tests/Tokenizers/TokenizerBuilderTests.cs
+++ b/test/Superpower.Tests/Tokenizers/TokenizerBuilderTests.cs
@@ -69,5 +69,17 @@ namespace Superpower.Tests.Tokenizers
             var msg = tokens.ToString();
             Assert.Equal("Syntax error (line 1, column 2): incomplete abc, unexpected end of input, expected `c`.", msg);
         }
+
+        [Fact]
+        public void InvalidDelimitedTokenAtEndIsReported()
+        {
+            var tokenizer = new TokenizerBuilder<string>()
+                .Match(Span.EqualTo("abc"), "abc", requireDelimiters: true)
+                .Match(Character.LetterOrDigit.AtLeastOnce(), "lod", requireDelimiters: true)
+                .Build();
+
+            var tokens = tokenizer.TryTokenize("abc_");
+            Assert.False(tokens.HasValue);
+        }
     }
 }


### PR DESCRIPTION
This bug results in partial but successful tokenization in some cases where tokenization should fail. Accidental "yield break" where "break" was intended :-)