### PR TITLE
This adds netstandard2.0 as a target framework

### DIFF
--- a/src/Superpower/Superpower.csproj
+++ b/src/Superpower/Superpower.csproj
@@ -3,7 +3,7 @@
     <Description>A parser combinator library for C#</Description>
     <VersionPrefix>2.1.0</VersionPrefix>
     <Authors>Datalust;Superpower Contributors;Sprache Contributors</Authors>
-    <TargetFrameworks>net45;netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.0;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Superpower</AssemblyName>


### PR DESCRIPTION
The current recommendation from my understanding is to target netstandard2.0 as it helps clean up package graph. eg https://twitter.com/ben_a_adams/status/1039989566021820418