### PR TITLE
Fix TextSpan.Equals() so that reference equality and length are considered

### DIFF
--- a/src/Superpower/Model/TextSpan.cs
+++ b/src/Superpower/Model/TextSpan.cs
@@ -173,7 +173,7 @@ namespace Superpower.Model
             next.EnsureHasValue();
             if (next.Source != Source) throw new ArgumentException("The spans are on different source strings.", nameof(next));
 #endif
-            var charCount = Length - next.Length;
+            var charCount = next.Position.Absolute - Position.Absolute;
             return First(charCount);
         }
 

--- a/src/Superpower/Model/TextSpan.cs
+++ b/src/Superpower/Model/TextSpan.cs
@@ -128,13 +128,16 @@ namespace Superpower.Model
         }
 
         /// <summary>
-        /// Compare a string span with another using source identity semantics - same source, same position, same length.
+        /// Compare a string span with another using source identity
+        /// semantics - same source, same position, same length.
         /// </summary>
         /// <param name="other">The other span.</param>
         /// <returns>True if the spans are the same.</returns>
         public bool Equals(TextSpan other)
         {
-            return string.Equals(Source, other.Source) && Position.Absolute == other.Position.Absolute;
+            return ReferenceEquals(Source, other.Source) &&
+                   Position.Absolute == other.Position.Absolute &&
+                   Length == other.Length;
         }
 
         /// <summary>

--- a/test/Superpower.Tests/StringSpanTests.cs
+++ b/test/Superpower.Tests/StringSpanTests.cs
@@ -41,6 +41,16 @@ namespace Superpower.Tests
         }
 
         [Fact]
+        public void EqualSpansAreEqualCase65()
+        {
+            var source = "123";
+            var one = Position.Zero.Advance(source[0]);
+            var t1 = new TextSpan(source);
+            var t2 = new TextSpan(source, one, 1);
+            Assert.Equal("1", t1.Until(t2).ToStringValue());
+        }
+
+        [Fact]
         public void SpansAtDifferentPositionsAreNotEqual()
         {
             var source = "111";

--- a/test/Superpower.Tests/StringSpanTests.cs
+++ b/test/Superpower.Tests/StringSpanTests.cs
@@ -13,6 +13,42 @@ namespace Superpower.Tests
             Assert.Throws<InvalidOperationException>(() => span.ToStringValue());
         }
 
+        [Fact]
+        public void IdenticalSpansAreEqual()
+        {
+            var source = "123";
+            var t1 = new TextSpan(source, Position.Zero, 1);
+            var t2 = new TextSpan(source, Position.Zero, 1);
+            Assert.Equal(t1, t2);
+        }
+
+        [Fact]
+        public void SpansFromDifferentSourcesAreNotEqual()
+        {
+            string source1 = "123", source2 = "1234".Substring(0, 3);
+            var t1 = new TextSpan(source1, Position.Zero, 1);
+            var t2 = new TextSpan(source2, Position.Zero, 1);
+            Assert.NotEqual(t1, t2);
+        }
+
+        [Fact]
+        public void DifferentLengthSpansAreNotEqual()
+        {
+            var source = "123";
+            var t1 = new TextSpan(source, Position.Zero, 1);
+            var t2 = new TextSpan(source, Position.Zero, 2);
+            Assert.NotEqual(t1, t2);
+        }
+
+        [Fact]
+        public void SpansAtDifferentPositionsAreNotEqual()
+        {
+            var source = "111";
+            var t1 = new TextSpan(source, Position.Zero, 1);
+            var t2 = new TextSpan(source, new Position(1, 1, 1), 1);
+            Assert.NotEqual(t1, t2);
+        }
+
         [Theory]
         [InlineData("Hello", 0, 5, "Hello")]
         [InlineData("Hello", 1, 4, "ello")]


### PR DESCRIPTION
The primary purpose of `TextSpan.Equals()` is in comparing remainders when determining whether a parser consumed input. The implementation and doc/intention diverge, this is what _should_ be considered, but we'll have to be on the lookout for parsers broken by this subtle change (shouldn't be many, if any).

Fixes #64.