### PR TITLE
Fix numeric parsers to accept Latin script digits only

### DIFF
--- a/sample/IntCalc/ArithmeticExpressionTokenizer.cs
+++ b/sample/IntCalc/ArithmeticExpressionTokenizer.cs
@@ -27,13 +27,14 @@ namespace IntCalc
             {
                 ArithmeticExpressionToken charToken;
 
-                if (char.IsDigit(next.Value))
+                var ch = next.Value;
+                if (ch >= '0' && ch <= '9')
                 {
                     var integer = Numerics.Integer(next.Location);
                     next = integer.Remainder.ConsumeChar();
                     yield return Result.Value(ArithmeticExpressionToken.Number, integer.Location, integer.Remainder);
                 }
-                else if (_operators.TryGetValue(next.Value, out charToken))
+                else if (_operators.TryGetValue(ch, out charToken))
                 {
                     yield return Result.Value(charToken, next.Location, next.Remainder);
                     next = next.Remainder.ConsumeChar();

--- a/src/Superpower/Parsers/Numerics.cs
+++ b/src/Superpower/Parsers/Numerics.cs
@@ -35,7 +35,7 @@ namespace Superpower.Parsers
         public static TextParser<TextSpan> Natural { get; } = input =>
         {
             var next = input.ConsumeChar();
-            if (!next.HasValue || !char.IsDigit(next.Value))
+            if (!next.HasValue || !CharInfo.IsLatinDigit(next.Value))
                 return Result.Empty<TextSpan>(input, ExpectedDigit);
 
             TextSpan remainder;
@@ -43,7 +43,7 @@ namespace Superpower.Parsers
             {
                 remainder = next.Remainder;
                 next = remainder.ConsumeChar();
-            } while (next.HasValue && char.IsDigit(next.Value));
+            } while (next.HasValue && CharInfo.IsLatinDigit(next.Value));
 
             return Result.Value(input.Until(remainder), input, remainder);
         };
@@ -55,7 +55,7 @@ namespace Superpower.Parsers
         {
             var next = input.ConsumeChar();
             
-            if (!next.HasValue || !char.IsDigit(next.Value))
+            if (!next.HasValue || !CharInfo.IsLatinDigit(next.Value))
                 return Result.Empty<uint>(input, ExpectedDigit);
 
             TextSpan remainder;
@@ -65,7 +65,7 @@ namespace Superpower.Parsers
                 val = 10 * val + (uint)(next.Value - '0');
                 remainder = next.Remainder;
                 next = remainder.ConsumeChar();
-            } while (next.HasValue && char.IsDigit(next.Value));
+            } while (next.HasValue && CharInfo.IsLatinDigit(next.Value));
             
             return Result.Value(val, input, remainder);
         };
@@ -77,7 +77,7 @@ namespace Superpower.Parsers
         {
             var next = input.ConsumeChar();
             
-            if (!next.HasValue || !char.IsDigit(next.Value))
+            if (!next.HasValue || !CharInfo.IsLatinDigit(next.Value))
                 return Result.Empty<ulong>(input, ExpectedDigit);
 
             TextSpan remainder;
@@ -87,7 +87,7 @@ namespace Superpower.Parsers
                 val = 10 * val + (ulong)(next.Value - '0');
                 remainder = next.Remainder;
                 next = remainder.ConsumeChar();
-            } while (next.HasValue && char.IsDigit(next.Value));
+            } while (next.HasValue && CharInfo.IsLatinDigit(next.Value));
             
             return Result.Value(val, input, remainder);
         };
@@ -105,7 +105,7 @@ namespace Superpower.Parsers
             if (next.Value == '-' || next.Value == '+')
                 next = next.Remainder.ConsumeChar();
 
-            if (!next.HasValue || !char.IsDigit(next.Value))
+            if (!next.HasValue || !CharInfo.IsLatinDigit(next.Value))
                 return Result.Empty<TextSpan>(input, ExpectedDigit);
 
             TextSpan remainder;
@@ -113,7 +113,7 @@ namespace Superpower.Parsers
             {
                 remainder = next.Remainder;
                 next = remainder.ConsumeChar();
-            } while (next.HasValue && char.IsDigit(next.Value));
+            } while (next.HasValue && CharInfo.IsLatinDigit(next.Value));
 
             return Result.Value(input.Until(remainder), input, remainder);
         };
@@ -140,7 +140,7 @@ namespace Superpower.Parsers
                 next = next.Remainder.ConsumeChar();
             }
             
-            if (!next.HasValue || !char.IsDigit(next.Value))
+            if (!next.HasValue || !CharInfo.IsLatinDigit(next.Value))
                 return Result.Empty<int>(input, ExpectedDigit);
 
             TextSpan remainder;
@@ -150,7 +150,7 @@ namespace Superpower.Parsers
                 val = 10 * val + (next.Value - '0');
                 remainder = next.Remainder;
                 next = remainder.ConsumeChar();
-            } while (next.HasValue && char.IsDigit(next.Value));
+            } while (next.HasValue && CharInfo.IsLatinDigit(next.Value));
 
             if (negative)
                 val = -val;
@@ -180,7 +180,7 @@ namespace Superpower.Parsers
                 next = next.Remainder.ConsumeChar();
             }
             
-            if (!next.HasValue || !char.IsDigit(next.Value))
+            if (!next.HasValue || !CharInfo.IsLatinDigit(next.Value))
                 return Result.Empty<long>(input, ExpectedDigit);
 
             TextSpan remainder;
@@ -190,7 +190,7 @@ namespace Superpower.Parsers
                 val = 10 * val + (next.Value - '0');
                 remainder = next.Remainder;
                 next = remainder.ConsumeChar();
-            } while (next.HasValue && char.IsDigit(next.Value));
+            } while (next.HasValue && CharInfo.IsLatinDigit(next.Value));
 
             if (negative)
                 val = -val;

--- a/src/Superpower/Util/CharInfo.cs
+++ b/src/Superpower/Util/CharInfo.cs
@@ -16,14 +16,19 @@ namespace Superpower.Util
 {
     static class CharInfo
     {
+        public static bool IsLatinDigit(char ch)
+        {
+            return ch >= '0' && ch <= '9';
+        }
+
         public static bool IsHexDigit(char ch)
         {
-            return char.IsDigit(ch) || ch >= 'a' && ch <= 'f' || ch >= 'A' && ch <= 'F';
+            return IsLatinDigit(ch) || ch >= 'a' && ch <= 'f' || ch >= 'A' && ch <= 'F';
         }
 
         public static int HexValue(char ch)
         {
-            if (char.IsDigit(ch))
+            if (IsLatinDigit(ch))
                 return ch - '0';
 
             if (ch >= 'a' && ch <= 'f')

--- a/test/Superpower.Benchmarks/ArithmeticExpressionScenario/ArithmeticExpressionTokenizer.cs
+++ b/test/Superpower.Benchmarks/ArithmeticExpressionScenario/ArithmeticExpressionTokenizer.cs
@@ -26,13 +26,14 @@ namespace Superpower.Benchmarks.ArithmeticExpressionScenario
             {
                 ArithmeticExpressionToken charToken;
 
-                if (char.IsDigit(next.Value))
+                var ch = next.Value;
+                if (ch >= '0' && ch <= '9')
                 {
                     var integer = Numerics.Integer(next.Location);
                     next = integer.Remainder.ConsumeChar();
                     yield return Result.Value(ArithmeticExpressionToken.Number, integer.Location, integer.Remainder);
                 }
-                else if (_operators.TryGetValue(next.Value, out charToken))
+                else if (_operators.TryGetValue(ch, out charToken))
                 {
                     yield return Result.Value(charToken, next.Location, next.Remainder);
                     next = next.Remainder.ConsumeChar();

--- a/test/Superpower.Benchmarks/NumberListScenario/NumberListTokenizer.cs
+++ b/test/Superpower.Benchmarks/NumberListScenario/NumberListTokenizer.cs
@@ -15,7 +15,8 @@ namespace Superpower.Benchmarks.NumberListScenario
 
             do
             {
-                if (char.IsDigit(next.Value))
+                var ch = next.Value;
+                if (ch >= '0' && ch <= '9')
                 {
                     var integer = Numerics.Integer(next.Location);
                     next = integer.Remainder.ConsumeChar();

--- a/test/Superpower.Tests/ArithmeticExpressionScenario/ArithmeticExpressionTokenizer.cs
+++ b/test/Superpower.Tests/ArithmeticExpressionScenario/ArithmeticExpressionTokenizer.cs
@@ -24,13 +24,14 @@ namespace Superpower.Tests.ArithmeticExpressionScenario
 
             do
             {
-                if (char.IsDigit(next.Value))
+                var ch = next.Value;
+                if (ch >= '0' && ch <= '9')
                 {
                     var natural = Numerics.Natural(next.Location);
                     next = natural.Remainder.ConsumeChar();
                     yield return Result.Value(ArithmeticExpressionToken.Number, natural.Location, natural.Remainder);
                 }
-                else if (_operators.TryGetValue(next.Value, out var charToken))
+                else if (_operators.TryGetValue(ch, out var charToken))
                 {
                     yield return Result.Value(charToken, next.Location, next.Remainder);
                     next = next.Remainder.ConsumeChar();

--- a/test/Superpower.Tests/NumberListScenario/NumberListTokenizer.cs
+++ b/test/Superpower.Tests/NumberListScenario/NumberListTokenizer.cs
@@ -22,7 +22,8 @@ namespace Superpower.Tests.NumberListScenario
 
             do
             {
-                if (char.IsDigit(next.Value))
+                var ch = next.Value;
+                if (ch >= '0' && ch <= '9')
                 {
                     var integer = Numerics.Integer(next.Location);
                     next = integer.Remainder.ConsumeChar();

--- a/test/Superpower.Tests/Parsers/NumericsTests.cs
+++ b/test/Superpower.Tests/Parsers/NumericsTests.cs
@@ -15,6 +15,8 @@ namespace Superpower.Tests.Parsers
         [InlineData("1.1", false)]
         [InlineData("a", false)]
         [InlineData("", false)]
+        [InlineData("\u0669\u0661\u0660", false)] // 910 in Arabic
+        [InlineData("9\u0661\u0660", false)] // 9 in Latin then 10 in Arabic
         public void IntegersAreRecognized(string input, bool isMatch)
         {
             AssertParser.FitsTheory(Numerics.Integer, input, isMatch);
@@ -29,6 +31,8 @@ namespace Superpower.Tests.Parsers
         [InlineData("1.1", false)]
         [InlineData("a", false)]
         [InlineData("", false)]
+        [InlineData("\u0669\u0661\u0660", false)] // 910 in Arabic
+        [InlineData("9\u0661\u0660", false)] // 9 in Latin then 10 in Arabic
         public void NaturalNumbersAreRecognized(string input, bool isMatch)
         {
             AssertParser.FitsTheory(Numerics.Natural, input, isMatch);
@@ -44,6 +48,8 @@ namespace Superpower.Tests.Parsers
         [InlineData("0123456789abcdef", true)]
         [InlineData("g", false)]
         [InlineData("", false)]
+        [InlineData("\u0669\u0661\u0660", false)] // 910 in Arabic
+        [InlineData("9\u0661\u0660", false)] // 9 in Latin then 10 in Arabic
         public void HexDigitsAreRecognized(string input, bool isMatch)
         {
             AssertParser.FitsTheory(Numerics.HexDigits, input, isMatch);

--- a/test/Superpower.Tests/SExpressionScenario/SExpressionTokenizer.cs
+++ b/test/Superpower.Tests/SExpressionScenario/SExpressionTokenizer.cs
@@ -25,7 +25,7 @@ namespace Superpower.Tests.SExpressionScenario
                     yield return Result.Value(SExpressionToken.RParen, next.Location, next.Remainder);
                     next = next.Remainder.ConsumeChar();
                 }
-                else if (char.IsDigit(next.Value))
+                else if (next.Value >= '0' && next.Value <= '9')
                 {
                     var integer = Numerics.Integer(next.Location);
                     next = integer.Remainder.ConsumeChar();


### PR DESCRIPTION
[`Char.IsDigit`][CharIsDigit] has a very wide, Unicode-based, definition of what's a digit. It returns `true` for digits from the various scripts shown in the table below:

|   0   |  1 |  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9 | Script                           |
|:-----:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|---------------------------------|
|   0   |  1 |  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9 | Latin                           |
| 〇/零 | 一 | 二 | 三 | 四 | 五 | 六 | 七 | 八 | 九 | East Asia                       |
|  ο/ō  | Αʹ | Βʹ | Γʹ | Δʹ | Εʹ | Ϛʹ | Ζʹ | Ηʹ | Θʹ | Modern Greek                    |
|       |  א |  ב |  ג |  ד |  ה |  ו |  ז |  ח |  ט | Hebrew                          |
|   ०   |  १ |  २ |  ३ |  ४ |  ५ |  ६ |  ७ |  ८ |  ९ | Devanagari                      |
|   ૦   |  ૧ |  ૨ |  ૩ |  ૪ |  ૫ |  ૬ |  ૭ |  ૮ |  ૯ | Gujarati                        |
|   ੦   |  ੧ |  ੨ |  ੩ |  ੪ |  ੫ |  ੬ |  ੭ |  ੮ |  ੯ | Gurmukhi                        |
|   ༠   |  ༡ |  ༢ |  ༣ |  ༤ |  ༥ |  ༦ |  ༧ |  ༨ |  ༩ | Tibetan                         |
|   ০   |  ১ |  ২ |  ৩ |  ৪ |  ৫ |  ৬ |  ৭ |  ৮ |  ৯ | Eastern Nagari                  |
|   ೦   |  ೧ |  ೨ |  ೩ |  ೪ |  ೫ |  ೬ |  ೭ |  ೮ |  ೯ | Kannada                         |
|   ୦   |  ୧ |  ୨ |  ୩ |  ୪ |  ୫ |  ୬ |  ୭ |  ୮ |  ୯ | Odia                            |
|   ൦   |  ൧ |  ൨ |  ൩ |  ൪ |  ൫ |  ൬ |  ൭ |  ൮ |  ൯ | Malayalam                       |
|   0   |  ௧ |  ௨ |  ௩ |  ௪ |  ௫ |  ௬ |  ௭ |  ௮ |  ௯ | Tamil                           |
|   ౦   |  ౧ |  ౨ |  ౩ |  ౪ |  ౫ |  ౬ |  ౭ |  ౮ |  ౯ | Telugu                          |
|   ០   |  ១ |  ២ |  ៣ |  ៤ |  ៥ |  ៦ |  ៧ |  ៨ |  ៩ | Khmer                           |
|   ๐   |  ๑ |  ๒ |  ๓ |  ๔ |  ๕ |  ๖ |  ๗ |  ๘ |  ๙ | Thai                            |
|   ໐   |  ໑ |  ໒ |  ໓ |  ໔ |  ໕ |  ໖ |  ໗ |  ໘ |  ໙ | Lao                             |
|   ၀   |  ၁ |  ၂ |  ၃ |  ၄ |  ၅ |  ၆ |  ၇ |  ၈ |  ၉ | Burmese                         |
|   ٠   |  ١ |  ٢ |  ٣ |  ٤ |  ٥ |  ٦ |  ٧ |  ٨ |  ٩ | Arabic                          |
|   ۰   |  ۱ |  ۲ |  ۳ |  ۴ |  ۵ |  ۶ |  ۷ |  ۸ |  ۹ | Persian (Farsi) / Dari / Pashto |
|   ۰   |  ۱ |  ۲ |  ۳ |  ۴ |  ۵ |  ۶ |  ۷ |  ۸ |  ۹ | Urdu / Shahmukhi                |

Source: [Glyph comparison table](https://en.wikipedia.org/wiki/Hindu%E2%80%93Arabic_numeral_system#Glyph_comparison) from the [Hindu–Arabic numeral system](https://en.wikipedia.org/wiki/Hindu–Arabic_numeral_system) entry in [Wikipedia](https://en.wikipedia.org/wiki/Wikipedia).

I believe what's intended most of the time is recognizing digits from just the Latin script (or ASCII character set) and this PR fixes the numeric parsers (and some more) to do just that. Prior to this, for example, "٩١٠" (910 in Arabic) would be recognized as an integer.

Do note, however, that I have left `Character.Digit` parser as-is.


[CharIsDigit]: https://docs.microsoft.com/en-us/dotnet/api/system.char.isdigit?view=netframework-4.7.2
