### PR TITLE
Fixes #76, incorrect remainder used when Many() backtracks

### DIFF
--- a/src/Superpower/Combinators.cs
+++ b/src/Superpower/Combinators.cs
@@ -410,7 +410,7 @@ namespace Superpower
                 if (!r.Backtrack && r.IsPartial(@from))
                     return TokenListParserResult.CastEmpty<TKind, T, T[]>(r);
 
-                return TokenListParserResult.Value(result.ToArray(), input, r.Remainder);
+                return TokenListParserResult.Value(result.ToArray(), input, from);
             };
         }
 
@@ -444,7 +444,7 @@ namespace Superpower
                 if (!r.Backtrack && r.IsPartial(from))
                     return Result.CastEmpty<T, T[]>(r);
 
-                return Result.Value(result.ToArray(), input, r.Remainder);
+                return Result.Value(result.ToArray(), input, from);
             };
         }
 
@@ -476,7 +476,7 @@ namespace Superpower
                 if (!r.Backtrack && r.IsPartial(from))
                     return Result.CastEmpty<T, Unit>(r);
 
-                return Result.Value(Unit.Value, input, r.Remainder);
+                return Result.Value(Unit.Value, input, from);
             };
         }
 

--- a/test/Superpower.Tests/Combinators/ManyCombinatorTests.cs
+++ b/test/Superpower.Tests/Combinators/ManyCombinatorTests.cs
@@ -57,5 +57,14 @@ namespace Superpower.Tests.Combinators
             var list = ab.Many();
             AssertParser.Fails(list, "ababa");
         }
+
+        [Fact]
+        public void ManySucceedsWithBacktrackedPartialItemMatch()
+        {
+            var ab = Character.EqualTo('a').Then(_ => Character.EqualTo('b'));
+            var ac = Character.EqualTo('a').Then(_ => Character.EqualTo('c'));
+            var list = Span.MatchedBy(ab.Try().Many().Then(_ => ac));
+            AssertParser.SucceedsWithAll(list, "ababac");
+        }
     }
 }

--- a/test/Superpower.Tests/Combinators/ManyCombinatorTests.cs
+++ b/test/Superpower.Tests/Combinators/ManyCombinatorTests.cs
@@ -66,5 +66,21 @@ namespace Superpower.Tests.Combinators
             var list = Span.MatchedBy(ab.Try().Many().Then(_ => ac));
             AssertParser.SucceedsWithAll(list, "ababac");
         }
+        
+        [Fact]
+        public void ManyReportsCorrectErrorPositionForNonBacktrackingPartialItemMatch()
+        {
+            var ab = Character.EqualTo('a').Then(_ => Character.EqualTo('b'));
+            var list = ab.Many();
+            AssertParser.FailsWithMessage(list, "ababac", "Syntax error (line 1, column 6): unexpected `c`, expected `b`.");
+        }
+        
+        [Fact]
+        public void ManyReportsCorrectRemainderForBacktrackingPartialItemMatch()
+        {
+            var ab = Character.EqualTo('a').Then(_ => Character.EqualTo('b'));
+            var list = Span.MatchedBy(ab.Try().Many()).Select(s => s.ToStringValue());
+            AssertParser.SucceedsWith(list, "ababac", "abab");
+        }
     }
 }


### PR DESCRIPTION
Fixes #76.

Many succeeds on partial parsing of an item if backtracking is allowed, but in this case, would report the pre-backtracking remainder in its result.