### PR TITLE
add chain combinator for left associative operator with a seed

### DIFF
--- a/src/Superpower/Parse.cs
+++ b/src/Superpower/Parse.cs
@@ -187,6 +187,109 @@ namespace Superpower
                     ChainRightOperatorRest(operandValue, @operator, operand, apply)).Then(r => Return<TKind, T>(apply(opvalue, lastOperand, r))))
                     .Or(Return<TKind, T>(lastOperand));
         }
+
+        /// <summary>
+        /// Parse a sequence of operands connected by a left-associative operator
+        /// starting with a seed parser.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the seed parser and the result.</typeparam>
+        /// <typeparam name="TOperand">The type of the operands.</typeparam>
+        /// <typeparam name="TOperator">The type of the operator.</typeparam>
+        /// <param name="seed">The initial parser that starts the sequence.</param>
+        /// <param name="operator">A parser matching operators.</param>
+        /// <param name="operand">A parser matching operands.</param>
+        /// <param name="apply">A function combining the intermediate result with an operator and an operand into the result.</param>
+        /// <returns>The result of calling <paramref name="apply"/> successively on intermediate results and operands.</returns>
+        public static TextParser<TResult> ChainLeft<TOperand, TResult, TOperator>(
+            this TextParser<TResult> seed,
+            TextParser<TOperator> @operator,
+            TextParser<TOperand> operand,
+            Func<TResult, TOperator, TOperand, TResult> apply)
+        {
+            if (seed == null) throw new ArgumentNullException(nameof(seed));
+            if (@operator == null) throw new ArgumentNullException(nameof(@operator));
+            if (operand == null) throw new ArgumentNullException(nameof(operand));
+            if (apply == null) throw new ArgumentNullException(nameof(apply));
+
+            return input =>
+            {
+                var seedResult = seed(input);
+                if (!seedResult.HasValue)
+                    return seedResult;
+
+                var result = seedResult.Value;
+
+                var operatorResult = @operator(seedResult.Remainder);
+                while (operatorResult.HasValue)
+                {
+                    // If operator read any input, but failed to read complete input, we return error
+                    if (!operatorResult.HasValue)
+                        return Result.CastEmpty<TOperator, TResult>(operatorResult);
+
+                    var operandResult = operand(operatorResult.Remainder);
+
+                    if (!operandResult.HasValue)
+                        return Result.CastEmpty<TOperand, TResult>(operandResult);
+
+                    result = apply(result, operatorResult.Value, operandResult.Value);
+                    operatorResult = @operator(operandResult.Remainder);
+                }
+
+                return Result.Value(result, input, operatorResult.Remainder);
+            };
+        }
+
+        /// <summary>
+        /// Parse a sequence of operands connected by a left-associative operator
+        /// starting with a seed parser.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the seed parser and the result.</typeparam>
+        /// <typeparam name="TOperand">The type of the operands.</typeparam>
+        /// <typeparam name="TOperator">The type of the operator.</typeparam>
+        /// <typeparam name="TKind">The kind of token being parsed.</typeparam>
+        /// <param name="seed">The initial parser that starts the sequence.</param>
+        /// <param name="operator">A parser matching operators.</param>
+        /// <param name="operand">A parser matching operands.</param>
+        /// <param name="apply">A function combining the intermediate result with an operator and an operand into the result.</param>
+        /// <returns>The result of calling <paramref name="apply"/> successively on intermediate results and operands.</returns>
+        public static TokenListParser<TKind, TResult> ChainLeft<TKind, TOperand, TResult, TOperator>(
+            this TokenListParser<TKind, TResult> seed,
+            TokenListParser<TKind, TOperator> @operator,
+            TokenListParser<TKind, TOperand> operand,
+            Func<TResult, TOperator, TOperand, TResult> apply)
+        {
+            if (seed == null) throw new ArgumentNullException(nameof(seed));
+            if (@operator == null) throw new ArgumentNullException(nameof(@operator));
+            if (operand == null) throw new ArgumentNullException(nameof(operand));
+            if (apply == null) throw new ArgumentNullException(nameof(apply));
+
+            return input =>
+            {
+                var seedResult = seed(input);
+                if (!seedResult.HasValue)
+                    return seedResult;
+
+                var result = seedResult.Value;
+
+                var operatorResult = @operator(seedResult.Remainder);
+                while (operatorResult.HasValue)
+                {
+                    // If operator read any input, but failed to read complete input, we return error
+                    if (!operatorResult.HasValue)
+                        return TokenListParserResult.CastEmpty<TKind, TOperator, TResult>(operatorResult);
+
+                    var operandResult = operand(operatorResult.Remainder);
+
+                    if (!operandResult.HasValue)
+                        return TokenListParserResult.CastEmpty<TKind, TOperand, TResult>(operandResult);
+
+                    result = apply(result, operatorResult.Value, operandResult.Value);
+                    operatorResult = @operator(operandResult.Remainder);
+                }
+
+                return TokenListParserResult.Value(result, input, operatorResult.Remainder);
+            };
+        }
         
         /// <summary>
         /// Constructs a parser that will fail if the given parser succeeds,

--- a/test/Superpower.Tests/Combinators/ChainCombinatorTests.cs
+++ b/test/Superpower.Tests/Combinators/ChainCombinatorTests.cs
@@ -59,5 +59,18 @@ namespace Superpower.Tests.Combinators
 
             AssertParser.FailsAt(nPlusPlusN, "1+1", 2);
         }
+
+        [Fact]
+        public void SuccessLeftAssociativeChain()
+        {
+            string input = "A.1.2.3";
+            var seed = Character.EqualTo('A').Select(i => System.Collections.Immutable.ImmutableList.Create<int>());
+            var chainParser = seed.ChainLeft(
+                    Character.EqualTo('.'),
+                    Numerics.IntegerInt32,
+                    (r, o, i) => r.Add(i));
+
+            AssertParser.SucceedsWith(chainParser, input, System.Collections.Immutable.ImmutableList.Create<int>(1, 2, 3));
+        }
     }
 }


### PR DESCRIPTION
As suggested in [issue 81](https://github.com/datalust/superpower/issues/81), this is a built in combinator for situations where a chain of operands (separated by operators) have a different type than the result. This requires an initial seed value for the result and an accumulator function of type Func<TResult, TOperator, TOperand, TResult> .

The Combinator is equivalent to  
           from seed in Seed
           from chain in (
               from operator in Operator
               from operand in Operand
               select (operator, operand)
            ).Many()
           select  chain.Aggregate(seed, (accu, tuple) => f(accu, tuple.operator, tuple.operand))

One example would be `expr := variable  ( '.' identifier )* ` where a variable alone is a valid expression and variables have nested properties that can be accessed to make a valid expression.

Test coverage is minimal since it requires some more infrastructure in form of an AST to show the usage.
Let me know if you want me to add more test coverage and have ideas how to keep it small.
