### PR TITLE
Include error position information in ParseException (goes some way t…

### DIFF
--- a/src/Superpower/Combinators.cs
+++ b/src/Superpower/Combinators.cs
@@ -400,7 +400,7 @@ namespace Superpower
                 while (r.HasValue)
                 {
                     if (@from == r.Remainder) // Broken parser, not a failed parsing.
-                        throw new ParseException($"Many() cannot be applied to zero-width parsers; value {r.Value} at position {r.Location.Position}.");
+                        throw new ParseException($"Many() cannot be applied to zero-width parsers; value {r.Value} at position {r.Location.Position}.", r.ErrorPosition);
 
                     result.Add(r.Value);
                     @from = r.Remainder;
@@ -433,7 +433,7 @@ namespace Superpower
                 while (r.HasValue)
                 {
                     if (from == r.Remainder) // Broken parser, not a failed parsing.
-                        throw new ParseException($"Many() cannot be applied to zero-width parsers; value {r.Value} at position {r.Location.Position}.");
+                        throw new ParseException($"Many() cannot be applied to zero-width parsers; value {r.Value} at position {r.Location.Position}.", r.Location.Position);
 
                     result.Add(r.Value);
 
@@ -467,7 +467,7 @@ namespace Superpower
                 while (r.HasValue)
                 {
                     if (from == r.Remainder) // Broken parser, not a failed parsing.
-                        throw new ParseException($"IgnoreMany() cannot be applied to zero-width parsers; value {r.Value} at position {r.Location.Position}.");
+                        throw new ParseException($"IgnoreMany() cannot be applied to zero-width parsers; value {r.Value} at position {r.Location.Position}.", r.Location.Position);
 
                     from = r.Remainder;
                     r = parser(r.Remainder);

--- a/src/Superpower/ParseException.cs
+++ b/src/Superpower/ParseException.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using Superpower.Model;
 
 namespace Superpower
 {
@@ -22,23 +23,27 @@ namespace Superpower
     public class ParseException : Exception
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ParseException" /> class.
+        /// Initializes a new instance of the <see cref="ParseException" /> class with a specified error message.
         /// </summary>
-        public ParseException() { }
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="errorPosition"> position that the recorded error occurred at.</param>
+        public ParseException(string message, Position errorPosition) : this(message, errorPosition, null) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ParseException" /> class with a specified error message.
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
-        public ParseException(string message) : base(message) { }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ParseException" /> class with a specified error message 
-        /// and a reference to the inner exception that is the cause of this exception.
-        /// </summary>
-        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="errorPosition"> position that the recorded error occurred at.</param>
         /// <param name="innerException">The exception that is the cause of the current exception, 
         /// or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
-        public ParseException(string message, Exception innerException) : base(message, innerException) { }
+        public ParseException(string message, Position errorPosition, Exception innerException = null) : base(message, innerException)
+        {
+            ErrorPosition = errorPosition;
+        }
+
+        /// <summary>
+        /// The position that the recorded error occurred at
+        /// </summary>
+        public Position ErrorPosition { get; }
     }
 }

--- a/src/Superpower/ParserExtensions.cs
+++ b/src/Superpower/ParserExtensions.cs
@@ -74,7 +74,7 @@ namespace Superpower
             if (result.HasValue)
                 return result.Value;
 
-            throw new ParseException(result.ToString());
+            throw new ParseException(result.ToString(), result.ErrorPosition);
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace Superpower
             if (result.HasValue)
                 return result.Value;
 
-            throw new ParseException(result.ToString());
+            throw new ParseException(result.ToString(), result.ErrorPosition);
         }
 
         /// <summary>

--- a/src/Superpower/Tokenizer`1.cs
+++ b/src/Superpower/Tokenizer`1.cs
@@ -37,7 +37,7 @@ namespace Superpower
             if (result.HasValue)
                 return result.Value;
 
-            throw new ParseException(result.ToString());
+            throw new ParseException(result.ToString(), result.ErrorPosition);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Superpower
                     return Result.CastEmpty<TKind, TokenList<TKind>>(result);
 
                 if (result.Remainder == remainder) // Broken parser, not a failed parsing.
-                    throw new ParseException($"Zero-width tokens are not supported; token {Presentation.FormatExpectation(result.Value)} at position {result.Location.Position}.");
+                    throw new ParseException($"Zero-width tokens are not supported; token {Presentation.FormatExpectation(result.Value)} at position {result.Location.Position}.", result.Location.Position);
 
                 remainder = result.Remainder;
                 var token = new Token<TKind>(result.Value, result.Location.Until(result.Remainder));

--- a/src/Superpower/Tokenizers/TokenizerBuilder.cs
+++ b/src/Superpower/Tokenizers/TokenizerBuilder.cs
@@ -202,7 +202,7 @@ namespace Superpower.Tokenizers
                         if (attempt.HasValue)
                         {
                             if (attempt.Remainder == span) // Broken parser, not a failed parsing.
-                                throw new ParseException($"Zero-width tokens are not supported; token {Presentation.FormatExpectation(recognizer.Kind)} at position {attempt.Location.Position}.");
+                                throw new ParseException($"Zero-width tokens are not supported; token {Presentation.FormatExpectation(recognizer.Kind)} at position {attempt.Location.Position}.", attempt.Location.Position);
                             
                             match = Result.Value(recognizer.Kind, span, attempt.Remainder);
                             recognizerIndex = searchStart;


### PR DESCRIPTION
…o addressing issue #73)

I changed constructors on ParseException - the parameterless one is
standard for Exception classes but isn't very useful for a library that
has excellent messages and didn't appear to be used anywhere, so I
removed it; the other two constructors now receive an "errorPosition"
constructor since everywhere in the library that raises this exception
knows where the problem occurred.

I guess that, strictly speaking, this could be considered a breaking
change since any external code that raised its own ParseExceptions would
need changing.. I wonder how likely that is considered to be? An
alternative would be to restore the constructors that don't take an
"errorPosition" argument and to leave set "ErrorPosition" to
"ErrorPosition.Empty" if those constructors are called, though this
would require anyone interrogating the property to have to check the
"HasValue" property and conclude that this information isn't always
available (when I think that it should be!)