### PR TITLE
Optimized Parse.Sequence(...) combinator

### DIFF
--- a/Superpower.sln.DotSettings
+++ b/Superpower.sln.DotSettings
@@ -2,6 +2,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypeParameters/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="T" Suffix="" Style="AaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="AA_BB" /&gt;&lt;/Policy&gt;</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=allocs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=errloc/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=expsign/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=frac/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lparen/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Numerics/@EntryIndexedValue">True</s:Boolean>

--- a/sample/IntCalc/IntCalc.csproj
+++ b/sample/IntCalc/IntCalc.csproj
@@ -3,15 +3,13 @@
     <TargetFramework>netcoreapp1.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' "> 
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
     <AssemblyName>IntCalc</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IntCalc</PackageId>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -19,11 +17,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Superpower\Superpower.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/src/Superpower/Parse.cs
+++ b/src/Superpower/Parse.cs
@@ -260,5 +260,337 @@ namespace Superpower
         {
             return input => TokenListParserResult.Value(value, input, input);
         }
+
+        /// <summary>
+        /// Construct a parser applies two parsers in order and returns a tuple of their results.
+        /// </summary>
+        /// <typeparam name="TKind">The kind of the tokens being parsed.</typeparam>
+        /// <typeparam name="T">The type of the first value parsed.</typeparam>
+        /// <typeparam name="U">The type of the second value parsed.</typeparam>
+        /// <param name="parser1">The first parser to apply.</param>
+        /// <param name="parser2">The second parser to apply.</param>
+        /// <returns>The resulting parser.</returns>
+        public static TokenListParser<TKind, (T, U)> Sequence<TKind, T, U>(
+            TokenListParser<TKind, T> parser1,
+            TokenListParser<TKind, U> parser2)
+        {
+            if (parser1 == null) throw new ArgumentNullException(nameof(parser1));
+            if (parser2 == null) throw new ArgumentNullException(nameof(parser2));
+
+            return input =>
+            {
+                var rt = parser1(input);
+                if (!rt.HasValue)
+                    return TokenListParserResult.CastEmpty<TKind, T, (T, U)>(rt);
+
+                var ru = parser2(rt.Remainder);
+                if (!ru.HasValue)
+                    return TokenListParserResult.CastEmpty<TKind, U, (T, U)>(ru);
+
+                return TokenListParserResult.Value((rt.Value, ru.Value), input, ru.Remainder);
+            };
+        }
+
+        /// <summary>
+        /// Construct a parser applies three parsers in order and returns a tuple of their results.
+        /// </summary>
+        /// <typeparam name="TKind">The kind of the tokens being parsed.</typeparam>
+        /// <typeparam name="T">The type of the first value parsed.</typeparam>
+        /// <typeparam name="U">The type of the second value parsed.</typeparam>
+        /// <typeparam name="V">The type of the third value parsed.</typeparam>
+        /// <param name="parser1">The first parser to apply.</param>
+        /// <param name="parser2">The second parser to apply.</param>
+        /// <param name="parser3">The third parser to apply.</param>
+        /// <returns>The resulting parser.</returns>
+        public static TokenListParser<TKind, (T, U, V)> Sequence<TKind, T, U, V>(
+            TokenListParser<TKind, T> parser1,
+            TokenListParser<TKind, U> parser2,
+            TokenListParser<TKind, V> parser3)
+        {
+            if (parser1 == null) throw new ArgumentNullException(nameof(parser1));
+            if (parser2 == null) throw new ArgumentNullException(nameof(parser2));
+            if (parser3 == null) throw new ArgumentNullException(nameof(parser3));
+
+            return input =>
+            {
+                var rt = parser1(input);
+                if (!rt.HasValue)
+                    return TokenListParserResult.CastEmpty<TKind, T, (T, U, V)>(rt);
+
+                var ru = parser2(rt.Remainder);
+                if (!ru.HasValue)
+                    return TokenListParserResult.CastEmpty<TKind, U, (T, U, V)>(ru);
+
+                var rv = parser3(ru.Remainder);
+                if (!rv.HasValue)
+                    return TokenListParserResult.CastEmpty<TKind, V, (T, U, V)>(rv);
+
+                return TokenListParserResult.Value((rt.Value, ru.Value, rv.Value), input, rv.Remainder);
+            };
+        }
+                
+        /// <summary>
+        /// Construct a parser applies four parsers in order and returns a tuple of their results.
+        /// </summary>
+        /// <typeparam name="TKind">The kind of the tokens being parsed.</typeparam>
+        /// <typeparam name="T">The type of the first value parsed.</typeparam>
+        /// <typeparam name="U">The type of the second value parsed.</typeparam>
+        /// <typeparam name="V">The type of the third value parsed.</typeparam>
+        /// <typeparam name="W">The type of the fourth value parsed.</typeparam>
+        /// <param name="parser1">The first parser to apply.</param>
+        /// <param name="parser2">The second parser to apply.</param>
+        /// <param name="parser3">The third parser to apply.</param>
+        /// <param name="parser4">The fourth parser to apply.</param>
+        /// <returns>The resulting parser.</returns>
+        public static TokenListParser<TKind, (T, U, V, W)> Sequence<TKind, T, U, V, W>(
+            TokenListParser<TKind, T> parser1,
+            TokenListParser<TKind, U> parser2,
+            TokenListParser<TKind, V> parser3,
+            TokenListParser<TKind, W> parser4)
+        {
+            if (parser1 == null) throw new ArgumentNullException(nameof(parser1));
+            if (parser2 == null) throw new ArgumentNullException(nameof(parser2));
+            if (parser3 == null) throw new ArgumentNullException(nameof(parser3));
+            if (parser4 == null) throw new ArgumentNullException(nameof(parser4));
+
+            return input =>
+            {
+                var rt = parser1(input);
+                if (!rt.HasValue)
+                    return TokenListParserResult.CastEmpty<TKind, T, (T, U, V, W)>(rt);
+
+                var ru = parser2(rt.Remainder);
+                if (!ru.HasValue)
+                    return TokenListParserResult.CastEmpty<TKind, U, (T, U, V, W)>(ru);
+
+                var rv = parser3(ru.Remainder);
+                if (!rv.HasValue)
+                    return TokenListParserResult.CastEmpty<TKind, V, (T, U, V, W)>(rv);
+
+                var rw = parser4(rv.Remainder);
+                if (!rw.HasValue)
+                    return TokenListParserResult.CastEmpty<TKind, W, (T, U, V, W)>(rw);
+
+                return TokenListParserResult.Value((rt.Value, ru.Value, rv.Value, rw.Value), input, rw.Remainder);
+            };
+        }
+        
+        /// <summary>
+        /// Construct a parser applies five parsers in order and returns a tuple of their results.
+        /// </summary>
+        /// <typeparam name="TKind">The kind of the tokens being parsed.</typeparam>
+        /// <typeparam name="T">The type of the first value parsed.</typeparam>
+        /// <typeparam name="U">The type of the second value parsed.</typeparam>
+        /// <typeparam name="V">The type of the third value parsed.</typeparam>
+        /// <typeparam name="W">The type of the fourth value parsed.</typeparam>
+        /// <typeparam name="X">The type of the fifth value parsed.</typeparam>
+        /// <param name="parser1">The first parser to apply.</param>
+        /// <param name="parser2">The second parser to apply.</param>
+        /// <param name="parser3">The third parser to apply.</param>
+        /// <param name="parser4">The fourth parser to apply.</param>
+        /// <param name="parser5">The fifth parser to apply.</param>
+        /// <returns>The resulting parser.</returns>
+        public static TokenListParser<TKind, (T, U, V, W, X)> Sequence<TKind, T, U, V, W, X>(
+            TokenListParser<TKind, T> parser1,
+            TokenListParser<TKind, U> parser2,
+            TokenListParser<TKind, V> parser3,
+            TokenListParser<TKind, W> parser4,
+            TokenListParser<TKind, X> parser5)
+        {
+            if (parser1 == null) throw new ArgumentNullException(nameof(parser1));
+            if (parser2 == null) throw new ArgumentNullException(nameof(parser2));
+            if (parser3 == null) throw new ArgumentNullException(nameof(parser3));
+            if (parser4 == null) throw new ArgumentNullException(nameof(parser4));
+            if (parser5 == null) throw new ArgumentNullException(nameof(parser5));
+
+            return input =>
+            {
+                var rt = parser1(input);
+                if (!rt.HasValue)
+                    return TokenListParserResult.CastEmpty<TKind, T, (T, U, V, W, X)>(rt);
+
+                var ru = parser2(rt.Remainder);
+                if (!ru.HasValue)
+                    return TokenListParserResult.CastEmpty<TKind, U, (T, U, V, W, X)>(ru);
+
+                var rv = parser3(ru.Remainder);
+                if (!rv.HasValue)
+                    return TokenListParserResult.CastEmpty<TKind, V, (T, U, V, W, X)>(rv);
+
+                var rw = parser4(rv.Remainder);
+                if (!rw.HasValue)
+                    return TokenListParserResult.CastEmpty<TKind, W, (T, U, V, W, X)>(rw);
+
+                var rx = parser5(rw.Remainder);
+                if (!rx.HasValue)
+                    return TokenListParserResult.CastEmpty<TKind, X, (T, U, V, W, X)>(rx);
+
+                return TokenListParserResult.Value((rt.Value, ru.Value, rv.Value, rw.Value, rx.Value), input, rx.Remainder);
+            };
+        }
+
+        /// <summary>
+        /// Construct a parser applies two parsers in order and returns a tuple of their results.
+        /// </summary>
+        /// <typeparam name="T">The type of the first value parsed.</typeparam>
+        /// <typeparam name="U">The type of the second value parsed.</typeparam>
+        /// <param name="parser1">The first parser to apply.</param>
+        /// <param name="parser2">The second parser to apply.</param>
+        /// <returns>The resulting parser.</returns>
+        public static TextParser<(T, U)> Sequence<T, U>(
+            TextParser<T> parser1,
+            TextParser<U> parser2)
+        {
+            if (parser1 == null) throw new ArgumentNullException(nameof(parser1));
+            if (parser2 == null) throw new ArgumentNullException(nameof(parser2));
+
+            return input =>
+            {
+                var rt = parser1(input);
+                if (!rt.HasValue)
+                    return Result.CastEmpty<T, (T, U)>(rt);
+
+                var ru = parser2(rt.Remainder);
+                if (!ru.HasValue)
+                    return Result.CastEmpty<U, (T, U)>(ru);
+
+                return Result.Value((rt.Value, ru.Value), input, ru.Remainder);
+            };
+        }
+        
+        /// <summary>
+        /// Construct a parser applies three parsers in order and returns a tuple of their results.
+        /// </summary>
+        /// <typeparam name="T">The type of the first value parsed.</typeparam>
+        /// <typeparam name="U">The type of the second value parsed.</typeparam>
+        /// <typeparam name="V">The type of the third value parsed.</typeparam>
+        /// <param name="parser1">The first parser to apply.</param>
+        /// <param name="parser2">The second parser to apply.</param>
+        /// <param name="parser3">The third parser to apply.</param>
+        /// <returns>The resulting parser.</returns>
+        public static TextParser<(T, U, V)> Sequence<T, U, V>(
+            TextParser<T> parser1,
+            TextParser<U> parser2,
+            TextParser<V> parser3)
+        {
+            if (parser1 == null) throw new ArgumentNullException(nameof(parser1));
+            if (parser2 == null) throw new ArgumentNullException(nameof(parser2));
+            if (parser3 == null) throw new ArgumentNullException(nameof(parser3));
+
+            return input =>
+            {
+                var rt = parser1(input);
+                if (!rt.HasValue)
+                    return Result.CastEmpty<T, (T, U, V)>(rt);
+
+                var ru = parser2(rt.Remainder);
+                if (!ru.HasValue)
+                    return Result.CastEmpty<U, (T, U, V)>(ru);
+
+                var rv = parser3(ru.Remainder);
+                if (!rv.HasValue)
+                    return Result.CastEmpty<V, (T, U, V)>(rv);
+
+                return Result.Value((rt.Value, ru.Value, rv.Value), input, rv.Remainder);
+            };
+        }
+        
+        /// <summary>
+        /// Construct a parser applies four parsers in order and returns a tuple of their results.
+        /// </summary>
+        /// <typeparam name="T">The type of the first value parsed.</typeparam>
+        /// <typeparam name="U">The type of the second value parsed.</typeparam>
+        /// <typeparam name="V">The type of the third value parsed.</typeparam>
+        /// <typeparam name="W">The type of the fourth value parsed.</typeparam>
+        /// <param name="parser1">The first parser to apply.</param>
+        /// <param name="parser2">The second parser to apply.</param>
+        /// <param name="parser3">The third parser to apply.</param>
+        /// <param name="parser4">The fourth parser to apply.</param>
+        /// <returns>The resulting parser.</returns>
+        public static TextParser<(T, U, V, W)> Sequence<T, U, V, W>(
+            TextParser<T> parser1,
+            TextParser<U> parser2,
+            TextParser<V> parser3,
+            TextParser<W> parser4)
+        {
+            if (parser1 == null) throw new ArgumentNullException(nameof(parser1));
+            if (parser2 == null) throw new ArgumentNullException(nameof(parser2));
+            if (parser3 == null) throw new ArgumentNullException(nameof(parser3));
+            if (parser4 == null) throw new ArgumentNullException(nameof(parser4));
+
+            return input =>
+            {
+                var rt = parser1(input);
+                if (!rt.HasValue)
+                    return Result.CastEmpty<T, (T, U, V, W)>(rt);
+
+                var ru = parser2(rt.Remainder);
+                if (!ru.HasValue)
+                    return Result.CastEmpty<U, (T, U, V, W)>(ru);
+
+                var rv = parser3(ru.Remainder);
+                if (!rv.HasValue)
+                    return Result.CastEmpty<V, (T, U, V, W)>(rv);
+
+                var rw = parser4(rv.Remainder);
+                if (!rw.HasValue)
+                    return Result.CastEmpty<W, (T, U, V, W)>(rw);
+
+                return Result.Value((rt.Value, ru.Value, rv.Value, rw.Value), input, rw.Remainder);
+            };
+        }
+        
+        /// <summary>
+        /// Construct a parser applies five parsers in order and returns a tuple of their results.
+        /// </summary>
+        /// <typeparam name="T">The type of the first value parsed.</typeparam>
+        /// <typeparam name="U">The type of the second value parsed.</typeparam>
+        /// <typeparam name="V">The type of the third value parsed.</typeparam>
+        /// <typeparam name="W">The type of the fourth value parsed.</typeparam>
+        /// <typeparam name="X">The type of the fifth value parsed.</typeparam>
+        /// <param name="parser1">The first parser to apply.</param>
+        /// <param name="parser2">The second parser to apply.</param>
+        /// <param name="parser3">The third parser to apply.</param>
+        /// <param name="parser4">The fourth parser to apply.</param>
+        /// <param name="parser5">The fifth parser to apply.</param>
+        /// <returns>The resulting parser.</returns>
+        public static TextParser<(T, U, V, W, X)> Sequence<T, U, V, W, X>(
+            TextParser<T> parser1,
+            TextParser<U> parser2,
+            TextParser<V> parser3,
+            TextParser<W> parser4,
+            TextParser<X> parser5)
+        {
+            if (parser1 == null) throw new ArgumentNullException(nameof(parser1));
+            if (parser2 == null) throw new ArgumentNullException(nameof(parser2));
+            if (parser3 == null) throw new ArgumentNullException(nameof(parser3));
+            if (parser4 == null) throw new ArgumentNullException(nameof(parser4));
+            if (parser5 == null) throw new ArgumentNullException(nameof(parser5));
+
+            return input =>
+            {
+                var rt = parser1(input);
+                if (!rt.HasValue)
+                    return Result.CastEmpty<T, (T, U, V, W, X)>(rt);
+
+                var ru = parser2(rt.Remainder);
+                if (!ru.HasValue)
+                    return Result.CastEmpty<U, (T, U, V, W, X)>(ru);
+
+                var rv = parser3(ru.Remainder);
+                if (!rv.HasValue)
+                    return Result.CastEmpty<V, (T, U, V, W, X)>(rv);
+
+                var rw = parser4(rv.Remainder);
+                if (!rw.HasValue)
+                    return Result.CastEmpty<W, (T, U, V, W, X)>(rw);
+
+                var rx = parser5(rw.Remainder);
+                if (!rx.HasValue)
+                    return Result.CastEmpty<X, (T, U, V, W, X)>(rx);
+
+                return Result.Value((rt.Value, ru.Value, rv.Value, rw.Value, rx.Value), input, rx.Remainder);
+            };
+        }
     }
 }

--- a/src/Superpower/Superpower.csproj
+++ b/src/Superpower/Superpower.csproj
@@ -1,13 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' "> 
-    <TargetFrameworks>net45;netstandard1.0;netstandard2.0</TargetFrameworks>
-  </PropertyGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>A parser combinator library for C#</Description>
-    <VersionPrefix>2.3.1</VersionPrefix>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Datalust;Superpower Contributors;Sprache Contributors</Authors>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -22,18 +17,6 @@
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-  </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DefineConstants>$(DefineConstants);CHECKED</DefineConstants>
   </PropertyGroup>

--- a/test/Superpower.Benchmarks/SequencingBenchmark.cs
+++ b/test/Superpower.Benchmarks/SequencingBenchmark.cs
@@ -1,0 +1,61 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using Superpower.Parsers;
+using Superpower.Model;
+using Xunit;
+
+// ReSharper disable ParameterOnlyUsedForPreconditionCheck.Local
+
+namespace Superpower.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class SequencingBenchmark
+    {
+        static readonly string Numbers = "123";
+        static readonly TextSpan Input = new TextSpan(Numbers);
+
+        static void AssertValues((char First, char Second, char Third) numbers)
+        {
+            Assert.Equal('1', numbers.First);
+            Assert.Equal('2', numbers.Second);
+            Assert.Equal('3', numbers.Third);
+        }
+
+        [Fact]
+        public void Verify()
+        {
+            AssertValues(ApplyThen().Value);
+            AssertValues(ApplySequence().Value);
+        }
+
+        [Fact]
+        public void Benchmark()
+        {
+            BenchmarkRunner.Run<SequencingBenchmark>();
+        }
+
+        static readonly TextParser<(char, char, char)> ThenParser =
+            Character.Digit.Then(first => 
+                Character.Digit.Then(second =>
+                    Character.Digit.Then(third => Parse.Return((first, second, third)))));
+
+        [Benchmark(Baseline = true)]
+        public Result<(char, char, char)> ApplyThen()
+        {
+            return ThenParser(Input);
+        }
+
+        static readonly TextParser<(char, char, char)> SequenceParser =
+            Parse.Sequence(
+                Character.Digit,
+                Character.Digit,
+                Character.Digit)
+                .Select(t => t); // Even up the work done
+
+        [Benchmark]
+        public Result<(char, char, char)> ApplySequence()
+        {
+            return SequenceParser(Input);
+        }
+    }
+}

--- a/test/Superpower.Benchmarks/Superpower.Benchmarks.csproj
+++ b/test/Superpower.Benchmarks/Superpower.Benchmarks.csproj
@@ -10,11 +10,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
-    <PackageReference Include="Sprache" Version="2.1.0" />
+    <PackageReference Include="Sprache" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/test/Superpower.Tests/Combinators/BetweenCombinatorTests.cs
+++ b/test/Superpower.Tests/Combinators/BetweenCombinatorTests.cs
@@ -27,31 +27,31 @@ namespace Superpower.Tests.Combinators
         [Fact]
         public void BetweenSucceedsIfAllParsersSucceed()
         {
-            AssertParser.SucceedsWith( Character.EqualTo( 'a' ).Between( Character.EqualTo( '(' ), Character.EqualTo( ')' ) ), "(a)", 'a' );
+            AssertParser.SucceedsWith(Character.EqualTo('a').Between(Character.EqualTo('('), Character.EqualTo(')')), "(a)", 'a');
         }
 
         [Fact]
         public void TokenBetweenFailsIfLeftParserFails()
         {
-            AssertParser.Fails( Token.EqualTo( 'a' ).Between( Token.EqualTo( '(' ), Token.EqualTo( ')' ) ), "{a)" );
+            AssertParser.Fails(Token.EqualTo('a').Between(Token.EqualTo('('), Token.EqualTo(')')), "{a)");
         }
 
         [Fact]
         public void TokenBetweenFailsIfRightParserFails()
         {
-            AssertParser.Fails( Token.EqualTo( 'a' ).Between( Token.EqualTo( '(' ), Token.EqualTo( ')' ) ), "(a}" );
+            AssertParser.Fails(Token.EqualTo('a').Between(Token.EqualTo('('), Token.EqualTo(')')), "(a}");
         }
 
         [Fact]
         public void TokenBetweenFailsIfMiddleParserFails()
         {
-            AssertParser.Fails( Token.EqualTo( 'a' ).Between( Token.EqualTo( '(' ), Token.EqualTo( ')' ) ), "(b)" );
+            AssertParser.Fails(Token.EqualTo('a').Between(Token.EqualTo('('), Token.EqualTo(')')), "(b)");
         }
 
         [Fact]
         public void TokenBetweenSucceedsIfAllParsersSucceed()
         {
-            AssertParser.SucceedsWith( Token.EqualTo( 'a' ).Between( Token.EqualTo( '(' ), Token.EqualTo( ')' ) ), "(a)", 'a' );
+            AssertParser.SucceedsWith(Token.EqualTo('a').Between(Token.EqualTo('('), Token.EqualTo(')')), "(a)", 'a');
         }
     }
 }

--- a/test/Superpower.Tests/Combinators/SequenceCombinatorTests.cs
+++ b/test/Superpower.Tests/Combinators/SequenceCombinatorTests.cs
@@ -1,0 +1,89 @@
+﻿using Superpower.Model;
+using Superpower.Parsers;
+using Superpower.Tests.Support;
+using Xunit;
+
+namespace Superpower.Tests.Combinators
+{
+    public class SequenceCombinatorTests
+    {
+        [Fact]
+        public void Sequence2Succeeds()
+        {
+            var p = Parse.Sequence(Character.Digit, Character.AnyChar);
+            AssertParser.SucceedsWithAll(Span.MatchedBy(p), "1w");
+        }
+
+        [Fact]
+        public void Sequence3Succeeds()
+        {
+            var p = Parse.Sequence(Character.Digit, Character.AnyChar, Character.Upper);
+            AssertParser.SucceedsWithAll(Span.MatchedBy(p), "1wU");
+        }
+
+        [Fact]
+        public void Sequence4Succeeds()
+        {
+            var p = Parse.Sequence(Character.Digit, Character.AnyChar, Character.Upper, Character.Letter);
+            AssertParser.SucceedsWithAll(Span.MatchedBy(p), "1wUh");
+        }
+
+        [Fact]
+        public void Sequence5Succeeds()
+        {
+            var p = Parse.Sequence(Character.Digit, Character.AnyChar, Character.Upper, Character.Letter, Character.Lower);
+            AssertParser.SucceedsWithAll(Span.MatchedBy(p), "1wUhh");
+        }
+        
+        [Fact]
+        public void Sequence3ReportsCorrectErrorPosition()
+        {
+            var p = Parse.Sequence(Character.Digit, Character.AnyChar, Character.Upper);
+            AssertParser.FailsAt(Span.MatchedBy(p), "1w1g", 2);
+        }
+        
+        [Fact]
+        public void Sequence2TokenSucceeds()
+        {
+            // Issue - explicit tuple argument types are needed here; see:
+            // https://github.com/dotnet/csharplang/issues/258
+            // Keeping this instance as an example, but using the "cleaner" .Item1, .Item2 syntax below.
+            var p = Parse.Sequence(Token.EqualTo('1'), Token.EqualTo('w'))
+                .Select(((Token<char> a, Token<char> b) t) => new []{t.a, t.b});
+
+            AssertParser.SucceedsWithAll(p, "1w");
+        }
+
+        [Fact]
+        public void Sequence3TokenSucceeds()
+        {
+            var p = Parse.Sequence(Token.EqualTo('1'), Token.EqualTo('w'), Token.EqualTo('U'))
+                .Select(t => new []{t.Item1, t.Item2, t.Item3});
+            AssertParser.SucceedsWithAll(p, "1wU");
+        }
+
+        [Fact]
+        public void Sequence4TokenSucceeds()
+        {
+            var p = Parse.Sequence(Token.EqualTo('1'), Token.EqualTo('w'), Token.EqualTo('U'), Token.EqualTo('h'))
+                .Select(t => new []{t.Item1, t.Item2, t.Item3, t.Item4});
+            AssertParser.SucceedsWithAll(p, "1wUh");
+        }
+
+        [Fact]
+        public void Sequence5TokenSucceeds()
+        {
+            var p = Parse.Sequence(Token.EqualTo('1'), Token.EqualTo('w'), Token.EqualTo('U'), Token.EqualTo('h'), Token.EqualTo('h'))
+                .Select(t => new []{t.Item1, t.Item2, t.Item3, t.Item4, t.Item5});
+            AssertParser.SucceedsWithAll(p, "1wUhh");
+        }
+        
+        [Fact]
+        public void Sequence3TokenReportsCorrectErrorPosition()
+        {
+            var p = Parse.Sequence(Token.EqualTo('1'), Token.EqualTo('w'), Token.EqualTo('U'))
+                .Select(t => new []{t.Item1, t.Item2, t.Item3});
+            AssertParser.FailsAt(p, "1w1g", 2);
+        }
+    }
+}

--- a/test/Superpower.Tests/Superpower.Tests.csproj
+++ b/test/Superpower.Tests/Superpower.Tests.csproj
@@ -10,18 +10,18 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Superpower\Superpower.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/Superpower.Tests/Support/AssertParser.cs
+++ b/test/Superpower.Tests/Support/AssertParser.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Collections.Generic;
 using Xunit;
-using Superpower;
 using Superpower.Model;
 using System.Linq;
 


### PR DESCRIPTION
`Parse.Sequence()` is a non-allocating alternative to `Then()`. It avoids construction of nested parsers by flattening out the sequence.

A comparison from the benches:

```csharp
        static readonly TextParser<(char, char, char)> ThenParser =
            Character.Digit.Then(first => 
                Character.Digit.Then(second =>
                    Character.Digit.Then(third => Parse.Return((first, second, third)))));

        static readonly TextParser<(char, char, char)> SequenceParser =
            Parse.Sequence(
                Character.Digit,
                Character.Digit,
                Character.Digit)
                .Select(t => t); // Even up the work done
```

Results from running this on a small input:

|        Method |     Mean |     Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------- |---------:|----------:|---------:|------:|--------:|-------:|------:|------:|----------:|
|     ApplyThen | 519.6 ns | 10.233 ns | 13.31 ns |  1.00 |    0.00 | 0.1473 |     - |     - |     464 B |
| ApplySequence | 314.4 ns |  6.249 ns | 10.09 ns |  0.61 |    0.02 |      - |     - |     - |         - |

It's not expected that `Sequence` would always replace `Then`, but the difference in allocs will help boost possible "v3" perf quite a bit, in conjunction with a few other planned changes.

The PR is setting up for a longer, deeper 3.0 where some breaking changes are expected. Rather than start depending on _System.ValueTuple_ I made the (possibly rash) move to drop every target except .NET Standard 2.0. We can reconsider this down the track, but for now it'll keep the work-in-progress clean and simple.

The signature of `Sequence()` could be extended to include an additional "selector" argument, avoiding the need for a chained `Select()` call to unpack the tuple. Current C# limitations make lambdas accepting tuples [a bit ugly](https://github.com/dotnet/csharplang/issues/258) - but if there's any hope this will improve, my preferences tip towards the cleaner signature used in the current PR version.