### PR TITLE
Fix the JSON parser sample to allow strings ending in '\'.

### DIFF
--- a/sample/JsonParser/Program.cs
+++ b/sample/JsonParser/Program.cs
@@ -99,7 +99,7 @@ namespace JsonParser
         //    drops the items that it matches.
         static TextParser<Unit> JsonStringToken { get; } =
             from open in Character.EqualTo('"')
-            from content in Span.EqualTo("\\\"").Value(Unit.Value).Try()
+            from content in Character.EqualTo('\\').IgnoreThen(Character.AnyChar).Value(Unit.Value).Try()
                 .Or(Character.Except('"').Value(Unit.Value))
                 .IgnoreMany()
             from close in Character.EqualTo('"')


### PR DESCRIPTION
I noticed the tokenizer in the JSON sample would fail to parse strings like `"foo\\"`.

This fixes that by not looking specifically for `\"` but instead ignoring any character preceded by a `\` which ensures it won't be allowed to escape the ending quote if it's another `\`.