### PR TITLE
Implementations IEquatable<T> for custom structs.

### DIFF
--- a/src/Superpower/Model/Position.cs
+++ b/src/Superpower/Model/Position.cs
@@ -19,7 +19,7 @@ namespace Superpower.Model
     /// <summary>
     /// A position within a stream of character input.
     /// </summary>
-    public readonly struct Position
+    public readonly struct Position : IEquatable<Position>
     {
         /// <summary>
         /// The zero-based absolute index of the position.
@@ -88,5 +88,60 @@ namespace Superpower.Model
         {
             return $"{Absolute} (line {Line}, column {Column})";
         }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other">other</paramref> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(Position other) => Absolute == other.Absolute && Line == other.Line && Column == other.Column;
+
+        /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current instance.</param>
+        /// <returns>
+        /// true if <paramref name="obj">obj</paramref> and this instance are the same type and represent the same value; otherwise, false.
+        /// </returns>
+        public override bool Equals(object? obj) => obj is Position other && Equals(other);
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Absolute;
+                hashCode = (hashCode * 397) ^ Line;
+                hashCode = (hashCode * 397) ^ Column;
+                return hashCode;
+            }
+        }
+
+        /// <summary>
+        /// Implements the operator ==.
+        /// </summary>
+        /// <param name="left">The left.</param>
+        /// <param name="right">The right.</param>
+        /// <returns>
+        /// The result of the operator.
+        /// </returns>
+        public static bool operator ==(Position left, Position right) => left.Equals(right);
+
+        /// <summary>
+        /// Implements the operator !=.
+        /// </summary>
+        /// <param name="left">The left.</param>
+        /// <param name="right">The right.</param>
+        /// <returns>
+        /// The result of the operator.
+        /// </returns>
+        public static bool operator !=(Position left, Position right) => !left.Equals(right);
     }
 }

--- a/src/Superpower/Model/Result`1.cs
+++ b/src/Superpower/Model/Result`1.cs
@@ -14,6 +14,7 @@
 
 using Superpower.Util;
 using System;
+using System.Collections.Generic;
 
 namespace Superpower.Model
 {
@@ -21,7 +22,7 @@ namespace Superpower.Model
     /// The result of parsing from a text span.
     /// </summary>
     /// <typeparam name="T">The type of the value being parsed.</typeparam>
-    public struct Result<T>
+    public struct Result<T> : IEquatable<Result<T>>
     {
         readonly T _value;
 
@@ -123,6 +124,74 @@ namespace Superpower.Model
 
             return $"Syntax error{location}: {message}.";
         }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other">other</paramref> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(Result<T> other)
+        {
+            return EqualityComparer<T>.Default.Equals(_value, other._value) &&
+                   Location.Equals(other.Location) &&
+                   Remainder.Equals(other.Remainder) &&
+                   HasValue == other.HasValue &&
+                   ErrorMessage == other.ErrorMessage &&
+                   Equals(Expectations, other.Expectations) &&
+                   Backtrack == other.Backtrack;
+        }
+
+        /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current instance.</param>
+        /// <returns>
+        /// true if <paramref name="obj">obj</paramref> and this instance are the same type and represent the same value; otherwise, false.
+        /// </returns>
+        public override bool Equals(object? obj) => obj is Result<T> other && Equals(other);
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = EqualityComparer<T>.Default.GetHashCode(_value!);
+                hashCode = (hashCode * 397) ^ Location.GetHashCode();
+                hashCode = (hashCode * 397) ^ Remainder.GetHashCode();
+                hashCode = (hashCode * 397) ^ HasValue.GetHashCode();
+                hashCode = (hashCode * 397) ^ (ErrorMessage != null ? ErrorMessage.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Expectations != null ? Expectations.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ Backtrack.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        /// <summary>
+        /// Implements the operator ==.
+        /// </summary>
+        /// <param name="left">The left.</param>
+        /// <param name="right">The right.</param>
+        /// <returns>
+        /// The result of the operator.
+        /// </returns>
+        public static bool operator ==(Result<T> left, Result<T> right) => left.Equals(right);
+
+        /// <summary>
+        /// Implements the operator !=.
+        /// </summary>
+        /// <param name="left">The left.</param>
+        /// <param name="right">The right.</param>
+        /// <returns>
+        /// The result of the operator.
+        /// </returns>
+        public static bool operator !=(Result<T> left, Result<T> right) => !left.Equals(right);
 
         /// <summary>
         /// If the result is empty, format the fragment of text describing the error.

--- a/src/Superpower/Model/TokenListParserResult`2.cs
+++ b/src/Superpower/Model/TokenListParserResult`2.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using Superpower.Display;
 using Superpower.Util;
 
@@ -23,7 +24,7 @@ namespace Superpower.Model
     /// </summary>
     /// <typeparam name="T">The type of the value being parsed.</typeparam>
     /// <typeparam name="TKind">The kind of token being parsed.</typeparam>
-    public struct TokenListParserResult<TKind, T>
+    public struct TokenListParserResult<TKind, T> : IEquatable<TokenListParserResult<TKind, T>>
     {
         readonly T _value;
 
@@ -150,6 +151,76 @@ namespace Superpower.Model
 
             return $"Syntax error{location}: {message}.";
         }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other">other</paramref> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(TokenListParserResult<TKind, T> other)
+        {
+            return EqualityComparer<T>.Default.Equals(_value, other._value) &&
+                   Location.Equals(other.Location) &&
+                   Remainder.Equals(other.Remainder) &&
+                   HasValue == other.HasValue &&
+                   SubTokenErrorPosition.Equals(other.SubTokenErrorPosition) &&
+                   ErrorMessage == other.ErrorMessage &&
+                   Equals(Expectations, other.Expectations) &&
+                   Backtrack == other.Backtrack;
+        }
+
+        /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current instance.</param>
+        /// <returns>
+        /// true if <paramref name="obj">obj</paramref> and this instance are the same type and represent the same value; otherwise, false.
+        /// </returns>
+        public override bool Equals(object? obj) => obj is TokenListParserResult<TKind, T> other && Equals(other);
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table. 
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = EqualityComparer<T>.Default.GetHashCode(_value!);
+                hashCode = (hashCode * 397) ^ Location.GetHashCode();
+                hashCode = (hashCode * 397) ^ Remainder.GetHashCode();
+                hashCode = (hashCode * 397) ^ HasValue.GetHashCode();
+                hashCode = (hashCode * 397) ^ SubTokenErrorPosition.GetHashCode();
+                hashCode = (hashCode * 397) ^ (ErrorMessage != null ? ErrorMessage.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Expectations != null ? Expectations.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ Backtrack.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        /// <summary>
+        /// Implements the operator ==.
+        /// </summary>
+        /// <param name="left">The left.</param>
+        /// <param name="right">The right.</param>
+        /// <returns>
+        /// The result of the operator.
+        /// </returns>
+        public static bool operator ==(TokenListParserResult<TKind, T> left, TokenListParserResult<TKind, T> right) => left.Equals(right);
+
+        /// <summary>
+        /// Implements the operator !=.
+        /// </summary>
+        /// <param name="left">The left.</param>
+        /// <param name="right">The right.</param>
+        /// <returns>
+        /// The result of the operator.
+        /// </returns>
+        public static bool operator !=(TokenListParserResult<TKind, T> left, TokenListParserResult<TKind, T> right) => !left.Equals(right);
 
         /// <summary>
         /// If the result is empty, format the fragment of text describing the error.

--- a/src/Superpower/Model/Token`1.cs
+++ b/src/Superpower/Model/Token`1.cs
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+using System.Collections.Generic;
+
 namespace Superpower.Model
 {
     /// <summary>
     /// A token.
     /// </summary>
     /// <typeparam name="TKind">The type of the token's kind.</typeparam>
-    public struct Token<TKind>
+    public struct Token<TKind> : IEquatable<Token<TKind>>
     {
         /// <summary>
         /// The kind of the token.
@@ -70,5 +73,57 @@ namespace Superpower.Model
 
             return $"{Kind}@{Position}: {Span}";
         }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// true if the current object is equal to the <paramref name="other">other</paramref> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(Token<TKind> other) => EqualityComparer<TKind>.Default.Equals(Kind, other.Kind) && Span.Equals(other.Span);
+
+        /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current instance.</param>
+        /// <returns>
+        /// true if <paramref name="obj">obj</paramref> and this instance are the same type and represent the same value; otherwise, false.
+        /// </returns>
+        public override bool Equals(object? obj) => obj is Token<TKind> other && Equals(other);
+
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (EqualityComparer<TKind>.Default.GetHashCode(Kind!) * 397) ^ Span.GetHashCode();
+            }
+        }
+
+        /// <summary>
+        /// Implements the operator ==.
+        /// </summary>
+        /// <param name="left">The left.</param>
+        /// <param name="right">The right.</param>
+        /// <returns>
+        /// The result of the operator.
+        /// </returns>
+        public static bool operator ==(Token<TKind> left, Token<TKind> right) => left.Equals(right);
+
+        /// <summary>
+        /// Implements the operator !=.
+        /// </summary>
+        /// <param name="left">The left.</param>
+        /// <param name="right">The right.</param>
+        /// <returns>
+        /// The result of the operator.
+        /// </returns>
+        public static bool operator !=(Token<TKind> left, Token<TKind> right) => !left.Equals(right);
     }
 }

--- a/src/Superpower/Tokenizers/TokenizerBuilder.cs
+++ b/src/Superpower/Tokenizers/TokenizerBuilder.cs
@@ -30,7 +30,7 @@ namespace Superpower.Tokenizers
     /// produce.</typeparam>
     public class TokenizerBuilder<TKind>
     {
-        readonly struct Recognizer
+        readonly struct Recognizer : IEquatable<Recognizer>
         {
             public TextParser<Unit> Parser { get; }
             public bool IsIgnored { get; }
@@ -44,8 +44,34 @@ namespace Superpower.Tokenizers
                 Kind = kind;
                 IsDelimiter = isDelimiter;
             }
+
+            public bool Equals(Recognizer other)
+            {
+                return Parser.Equals(other.Parser) &&
+                       IsIgnored == other.IsIgnored &&
+                       EqualityComparer<TKind>.Default.Equals(Kind, other.Kind) &&
+                       IsDelimiter == other.IsDelimiter;
+            }
+
+            public override bool Equals(object? obj) => obj is Recognizer other && Equals(other);
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = Parser.GetHashCode();
+                    hashCode = (hashCode * 397) ^ IsIgnored.GetHashCode();
+                    hashCode = (hashCode * 397) ^ EqualityComparer<TKind>.Default.GetHashCode(Kind!);
+                    hashCode = (hashCode * 397) ^ IsDelimiter.GetHashCode();
+                    return hashCode;
+                }
+            }
+
+            public static bool operator ==(Recognizer left, Recognizer right) => left.Equals(right);
+
+            public static bool operator !=(Recognizer left, Recognizer right) => !left.Equals(right);
         }
-        
+
         readonly List<Recognizer> _recognizers = new List<Recognizer>();
         
         /// <summary>

--- a/test/Superpower.Tests/Model/PositionTests.cs
+++ b/test/Superpower.Tests/Model/PositionTests.cs
@@ -1,0 +1,86 @@
+﻿using Superpower.Model;
+using Xunit;
+
+namespace Superpower.Tests.Model
+{
+    public class PositionTests
+    {
+        [Fact]
+        public void IdenticalPositionsAreEqual()
+        {
+            var first = new Position(10, 20, 30);
+            var second = new Position(10, 20, 30);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+
+            Assert.True(result1);
+            Assert.True(result2);
+            Assert.True(result3);
+        }
+
+        [Fact]
+        public void PositionsWithDifferentAbsolutesAreNotEqual()
+        {
+            var first = new Position(10, 20, 30);
+            var second = new Position(20, 20, 30);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+            var result4 = first != second;
+
+            Assert.False(result1);
+            Assert.False(result2);
+            Assert.False(result3);
+            Assert.True(result4);
+        }
+
+        [Fact]
+        public void PositionsWithDifferentLinesAreNotEqual()
+        {
+            var first = new Position(10, 20, 30);
+            var second = new Position(10, 30, 30);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+            var result4 = first != second;
+
+            Assert.False(result1);
+            Assert.False(result2);
+            Assert.False(result3);
+            Assert.True(result4);
+        }
+
+        [Fact]
+        public void PositionsWithDifferentColumnsAreNotEqual()
+        {
+            var first = new Position(10, 20, 30);
+            var second = new Position(10, 20, 40);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+            var result4 = first != second;
+
+            Assert.False(result1);
+            Assert.False(result2);
+            Assert.False(result3);
+            Assert.True(result4);
+        }
+
+        [Fact]
+        public void IdenticalPositionsHaveTheSameHashCode()
+        {
+            var first = new Position(10, 20, 30);
+            var second = new Position(10, 20, 30);
+
+            var hashCode1 = first.GetHashCode();
+            var hashCode2 = second.GetHashCode();
+
+            Assert.Equal(hashCode1, hashCode2);
+        }
+    }
+}

--- a/test/Superpower.Tests/Model/ResultTests.cs
+++ b/test/Superpower.Tests/Model/ResultTests.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using Superpower.Model;
+using Xunit;
+
+namespace Superpower.Tests.Model
+{
+    public class ResultTests
+    {
+        [Fact]
+        public void IdenticalResultsAreEqual()
+        {
+            var first = new Result<char>(TextSpan.Empty, TextSpan.Empty, "errorMessage", Array.Empty<string>(), true);
+            var second= new Result<char>(TextSpan.Empty, TextSpan.Empty, "errorMessage", Array.Empty<string>(), true);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+
+            Assert.True(result1);
+            Assert.True(result2);
+            Assert.True(result3);
+        }
+
+        [Fact]
+        public void ResultsWithDifferentLocationsAreNotEqual()
+        {
+            var first = new Result<char>(TextSpan.Empty, TextSpan.Empty, "errorMessage", Array.Empty<string>(), true);
+            var second = new Result<char>(new TextSpan("source"), TextSpan.Empty, "errorMessage", Array.Empty<string>(), true);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+            var result4 = first != second;
+
+            Assert.False(result1);
+            Assert.False(result2);
+            Assert.False(result3);
+            Assert.True(result4);
+        }
+
+        [Fact]
+        public void ResultsWithDifferentRemaindersAreNotEqual()
+        {
+            var first = new Result<char>(TextSpan.Empty, TextSpan.Empty, "errorMessage", Array.Empty<string>(), true);
+            var second = new Result<char>(TextSpan.Empty, new TextSpan("source"), "errorMessage", Array.Empty<string>(), true);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+            var result4 = first != second;
+
+            Assert.False(result1);
+            Assert.False(result2);
+            Assert.False(result3);
+            Assert.True(result4);
+        }
+
+        [Fact]
+        public void ResultsWithDifferentErrorMessagesAreNotEqual()
+        {
+            var first = new Result<char>(TextSpan.Empty, TextSpan.Empty, "errorMessage1", Array.Empty<string>(), true);
+            var second = new Result<char>(TextSpan.Empty, TextSpan.Empty, "errorMessage2", Array.Empty<string>(), true);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+            var result4 = first != second;
+
+            Assert.False(result1);
+            Assert.False(result2);
+            Assert.False(result3);
+            Assert.True(result4);
+        }
+
+        [Fact]
+        public void ResultsWithDifferentExpectationsAreNotEqual()
+        {
+            var first = new Result<char>(TextSpan.Empty, TextSpan.Empty, "errorMessage", Array.Empty<string>(), true);
+            var second = new Result<char>(TextSpan.Empty, TextSpan.Empty, "errorMessage", null, true);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+            var result4 = first != second;
+
+            Assert.False(result1);
+            Assert.False(result2);
+            Assert.False(result3);
+            Assert.True(result4);
+        }
+
+        [Fact]
+        public void ResultsWithDifferentBacktracksAreNotEqual()
+        {
+            var first = new Result<char>(TextSpan.Empty, TextSpan.Empty, "errorMessage", Array.Empty<string>(), true);
+            var second = new Result<char>(TextSpan.Empty, TextSpan.Empty, "errorMessage", Array.Empty<string>(), false);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+            var result4 = first != second;
+
+            Assert.False(result1);
+            Assert.False(result2);
+            Assert.False(result3);
+            Assert.True(result4);
+        }
+
+        [Fact]
+        public void IdenticalResultsHaveTheSameHashCode()
+        {
+            var first = new Result<char>(TextSpan.Empty, TextSpan.Empty, "errorMessage", Array.Empty<string>(), true);
+            var second = new Result<char>(TextSpan.Empty, TextSpan.Empty, "errorMessage", Array.Empty<string>(), true);
+
+            var hashCode1 = first.GetHashCode();
+            var hashCode2 = second.GetHashCode();
+
+            Assert.Equal(hashCode1, hashCode2);
+        }
+    }
+}

--- a/test/Superpower.Tests/Model/TokenListParserResultTests.cs
+++ b/test/Superpower.Tests/Model/TokenListParserResultTests.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using Superpower.Model;
+using Xunit;
+
+namespace Superpower.Tests.Model
+{
+    public class TokenListParserResultTests
+    {
+        [Fact]
+        public void IdenticalTokenListParserResultsAreEqual()
+        {
+            var first = new TokenListParserResult<int, int>(TokenList<int>.Empty, TokenList<int>.Empty, Position.Empty, "errorMessage", Array.Empty<string>(), true);
+            var second = new TokenListParserResult<int, int>(TokenList<int>.Empty, TokenList<int>.Empty, Position.Empty, "errorMessage", Array.Empty<string>(), true);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+
+            Assert.True(result1);
+            Assert.True(result2);
+            Assert.True(result3);
+        }
+
+        [Fact]
+        public void TokenListParserResultsWithDifferentLocationsAreNotEqual()
+        {
+            var first = new TokenListParserResult<int, int>(TokenList<int>.Empty, TokenList<int>.Empty, Position.Empty, "errorMessage", Array.Empty<string>(), true);
+            var second = new TokenListParserResult<int, int>(new TokenList<int>(Array.Empty<Token<int>>()), TokenList<int>.Empty, Position.Empty, "errorMessage", Array.Empty<string>(), true);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+            var result4 = first != second;
+
+            Assert.False(result1);
+            Assert.False(result2);
+            Assert.False(result3);
+            Assert.True(result4);
+        }
+
+        [Fact]
+        public void TokenListParserResultsWithDifferentRemaindersAreNotEqual()
+        {
+            var first = new TokenListParserResult<int, int>(TokenList<int>.Empty, TokenList<int>.Empty, Position.Empty, "errorMessage", Array.Empty<string>(), true);
+            var second = new TokenListParserResult<int, int>(TokenList<int>.Empty, new TokenList<int>(Array.Empty<Token<int>>()), Position.Empty, "errorMessage", Array.Empty<string>(), true);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+            var result4 = first != second;
+
+            Assert.False(result1);
+            Assert.False(result2);
+            Assert.False(result3);
+            Assert.True(result4);
+        }
+
+        [Fact]
+        public void TokenListParserResultsWithDifferentPositionsAreNotEqual()
+        {
+            var first = new TokenListParserResult<int, int>(TokenList<int>.Empty, TokenList<int>.Empty, Position.Empty, "errorMessage", Array.Empty<string>(), true);
+            var second = new TokenListParserResult<int, int>(TokenList<int>.Empty, TokenList<int>.Empty, new Position(10, 5, 3), "errorMessage", Array.Empty<string>(), true);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+            var result4 = first != second;
+
+            Assert.False(result1);
+            Assert.False(result2);
+            Assert.False(result3);
+            Assert.True(result4);
+        }
+
+        [Fact]
+        public void TokenListParserResultsWithDifferentErrorMessagesAreNotEqual()
+        {
+            var first = new TokenListParserResult<int, int>(TokenList<int>.Empty, TokenList<int>.Empty, Position.Empty, "errorMessage1", Array.Empty<string>(), true);
+            var second = new TokenListParserResult<int, int>(TokenList<int>.Empty, TokenList<int>.Empty, Position.Empty, "errorMessage2", Array.Empty<string>(), true);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+            var result4 = first != second;
+
+            Assert.False(result1);
+            Assert.False(result2);
+            Assert.False(result3);
+            Assert.True(result4);
+        }
+
+        [Fact]
+        public void TokenListParserResultsWithDifferentExpectationsAreNotEqual()
+        {
+            var first = new TokenListParserResult<int, int>(TokenList<int>.Empty, TokenList<int>.Empty, Position.Empty, "errorMessage", Array.Empty<string>(), true);
+            var second = new TokenListParserResult<int, int>(TokenList<int>.Empty, TokenList<int>.Empty, Position.Empty, "errorMessage", null, true);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+            var result4 = first != second;
+
+            Assert.False(result1);
+            Assert.False(result2);
+            Assert.False(result3);
+            Assert.True(result4);
+        }
+
+        [Fact]
+        public void TokenListParserResultsWithDifferentBacktracksAreNotEqual()
+        {
+            var first = new TokenListParserResult<int, int>(TokenList<int>.Empty, TokenList<int>.Empty, Position.Empty, "errorMessage", Array.Empty<string>(), true);
+            var second = new TokenListParserResult<int, int>(TokenList<int>.Empty, TokenList<int>.Empty, Position.Empty, "errorMessage", Array.Empty<string>(), false);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+            var result4 = first != second;
+
+            Assert.False(result1);
+            Assert.False(result2);
+            Assert.False(result3);
+            Assert.True(result4);
+        }
+
+        [Fact]
+        public void IdenticalTokenListParserResultsHaveTheSameHashCode()
+        {
+            var first = new TokenListParserResult<int, int>(TokenList<int>.Empty, TokenList<int>.Empty, Position.Empty, "errorMessage", Array.Empty<string>(), true);
+            var second = new TokenListParserResult<int, int>(TokenList<int>.Empty, TokenList<int>.Empty, Position.Empty, "errorMessage", Array.Empty<string>(), true);
+
+            var hashCode1 = first.GetHashCode();
+            var hashCode2 = second.GetHashCode();
+
+            Assert.Equal(hashCode1, hashCode2);
+        }
+    }
+}

--- a/test/Superpower.Tests/Model/TokenTests.cs
+++ b/test/Superpower.Tests/Model/TokenTests.cs
@@ -1,0 +1,69 @@
+﻿using Superpower.Model;
+using Xunit;
+
+namespace Superpower.Tests.Model
+{
+    public class TokenTests
+    {
+        [Fact]
+        public void IdenticalTokensAreEqual()
+        {
+            var first = new Token<char>('c', TextSpan.Empty);
+            var second = new Token<char>('c', TextSpan.Empty);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+
+            Assert.True(result1);
+            Assert.True(result2);
+            Assert.True(result3);
+        }
+
+        [Fact]
+        public void TokensWithDifferentKindsAreNotEqual()
+        {
+            var first = new Token<char>('c', TextSpan.Empty);
+            var second = new Token<char>('d', TextSpan.Empty);
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+            var result4 = first != second;
+
+            Assert.False(result1);
+            Assert.False(result2);
+            Assert.False(result3);
+            Assert.True(result4);
+        }
+
+        [Fact]
+        public void TokensWithDifferentSpansAreNotEqual()
+        {
+            var first = new Token<char>('c', TextSpan.Empty);
+            var second = new Token<char>('c', new TextSpan("abc"));
+
+            var result1 = first.Equals(second);
+            var result2 = first.Equals((object)second);
+            var result3 = first == second;
+            var result4 = first != second;
+
+            Assert.False(result1);
+            Assert.False(result2);
+            Assert.False(result3);
+            Assert.True(result4);
+        }
+
+        [Fact]
+        public void IdenticalTokensHaveTheSameHashCode()
+        {
+            var first = new Token<char>('c', TextSpan.Empty);
+            var second = new Token<char>('c', TextSpan.Empty);
+
+            var hashCode1 = first.GetHashCode();
+            var hashCode2 = second.GetHashCode();
+
+            Assert.Equal(hashCode1, hashCode2);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Best practices recommend implementing an "IEquatable<T>" interface for custom structs. This improves the performance of comparison operations and eliminates boxing.