### PR TITLE
Fix divide example string

### DIFF
--- a/sample/IntCalc/ArithmeticExpressionToken.cs
+++ b/sample/IntCalc/ArithmeticExpressionToken.cs
@@ -18,7 +18,7 @@ namespace IntCalc
         [Token(Category = "operator", Example = "*")]
         Times,
 
-        [Token(Category = "operator", Example = "-")]
+        [Token(Category = "operator", Example = "/")]
         Divide,
 
         [Token(Example = "(")]


### PR DESCRIPTION
typo