### PR TITLE
Add index/range support for TextSpan

### DIFF
--- a/src/Superpower/Model/TextSpan.cs
+++ b/src/Superpower/Model/TextSpan.cs
@@ -271,7 +271,6 @@ namespace Superpower.Model
             return true;
         }
 
-
         /// <summary>
         /// Gets the character at the specified index in the text span.
         /// </summary>

--- a/src/Superpower/Model/TextSpan.cs
+++ b/src/Superpower/Model/TextSpan.cs
@@ -270,5 +270,53 @@ namespace Superpower.Model
             }
             return true;
         }
+
+
+        /// <summary>
+        /// Gets the character at the specified index in the text span.
+        /// </summary>
+        /// <param name="index">
+        /// The zero-based index of the character to get.
+        /// </param>
+        /// <returns>
+        /// The character at the specified index in the text span.
+        /// </returns>
+        public char this[int index]
+        {
+            get
+            {
+                this.EnsureHasValue();
+#if CHECKED
+                if ((uint)index >= (uint)Length)
+                    throw new ArgumentOutOfRangeException(nameof(index), index, "Index exceeds the source span's length.");
+#endif
+                return Source![Position.Absolute + index];
+            }
+        }
+        
+        /// <summary>
+        /// Forms a slice out of the current text span starting at the specified index.
+        /// </summary>
+        /// <param name="index">
+        /// The index at which to begin the slice.
+        /// </param>
+        /// <returns>
+        /// An text span that consists of all elements of the current array segment from <paramref name="index"/> to the end of the text span.
+        /// </returns>
+        public TextSpan Slice(int index)
+        {
+            return Skip(index);
+        }
+ 
+        /// <summary>
+        /// Forms a slice of the specified length out of the current text span starting at the specified index.
+        /// </summary>
+        /// <param name="index">The index at which to begin the slice.</param>
+        /// <param name="count">The desired length of the slice.</param>
+        /// <returns>An text span of <paramref name="count"/> elements starting at <paramref name="index"/>.</returns>
+        public TextSpan Slice(int index, int count)
+        {
+            return Skip(index).First(count);
+        }
     }
 }

--- a/test/Superpower.Tests/StringSpanTests.cs
+++ b/test/Superpower.Tests/StringSpanTests.cs
@@ -90,5 +90,38 @@ namespace Superpower.Tests
             var span = new TextSpan(str, new Position(offset, 1, offset + 1), length);
             Assert.False(span.EqualsValue(value));
         }
+
+        [Theory]
+        [InlineData("Hello", 0, 5)]
+        [InlineData("Hello", 0, 3)]
+        [InlineData("Hello", 1, 3)]
+        public void SliceWithLengthExtractsCorrectCharacters(string input, int index, int end)
+        {
+            var inputSpan = new TextSpan(input, new Position(0, 1, 1), input.Length);
+            var slice = inputSpan[index..end];
+            Assert.Equal(expected: input[index..end], actual: slice.ToStringValue());
+        }
+        
+        [Theory]
+        [InlineData("Hello", 0)]
+        [InlineData("Hello", 2)]
+        [InlineData("Hello", 5)]
+        public void SliceWithoutLengthExtractsCorrectCharacters(string input, int index)
+        {
+            var inputSpan = new TextSpan(input, new Position(0, 1, 1), input.Length);
+            var slice = inputSpan[index..];
+            Assert.Equal(expected: input[index..], actual: slice.ToStringValue());
+        }
+        
+        [Theory]
+        [InlineData("Hello", 0)]
+        [InlineData("Hello", 2)]
+        [InlineData("Hello", 4)]
+        public void IndexerExtractsCorrectCharacter(string input, int index)
+        {
+            var inputSpan = new TextSpan(input, new Position(0, 1, 1), input.Length);
+            var ch = inputSpan[index];
+            Assert.Equal(expected: input[index], actual: ch);
+        }
     }
 }


### PR DESCRIPTION
This PR adds to `TextSpan`, an indexer, and support for the range operator (`..`)

Exactly how well this is supported depends on the target framework of the application that uses this library:

- .NET Standard 2.1, .NET Core 3, or later: The feature just works (as demonstrated in the unit tests)
- .NET Standard 2.0, or .NET Framework, _with_ a polyfill package such as [IndexRange](https://www.nuget.org/packages/IndexRange) - again, it just works
- .NET Standard 2.0, or .NET Framework, _without_ a polyfill package:  The range operator isn't available, but the indexer and `Slice` methods work as expected.
