### PR TITLE
Feature/reintroduce text combinator

### DIFF
--- a/src/Superpower/Combinators.cs
+++ b/src/Superpower/Combinators.cs
@@ -540,6 +540,14 @@ namespace Superpower
             => parser.Select(chars => new string(chars));
 
         /// <summary>
+        /// Constructs a parser that converts a TextSpan-parser to a string-parser.
+        /// </summary>
+        /// <param name="parser">The parser.</param>
+        /// <returns>The resulting parser.</returns>
+        public static TextParser<string> Text(this TextParser<TextSpan> parser)
+            => parser.Select(textSpan => textSpan.ToStringValue());
+
+        /// <summary>
         /// Construct a parser that fails with error message <paramref name="errorMessage"/> when <paramref name="parser"/> fails.
         /// </summary>
         /// <typeparam name="TKind">The kind of the tokens being parsed.</typeparam>

--- a/src/Superpower/Combinators.cs
+++ b/src/Superpower/Combinators.cs
@@ -532,6 +532,14 @@ namespace Superpower
         }
 
         /// <summary>
+        /// Constructs a parser that converts a char[]-parser to a string-parser.
+        /// </summary>
+        /// <param name="parser">The parser.</param>
+        /// <returns>The resulting parser.</returns>
+        public static TextParser<string> Text(this TextParser<char[]> parser)
+            => parser.Select(chars => new string(chars));
+
+        /// <summary>
         /// Construct a parser that fails with error message <paramref name="errorMessage"/> when <paramref name="parser"/> fails.
         /// </summary>
         /// <typeparam name="TKind">The kind of the tokens being parsed.</typeparam>

--- a/test/Superpower.Tests/Combinators/TextCombinatorTests.cs
+++ b/test/Superpower.Tests/Combinators/TextCombinatorTests.cs
@@ -11,4 +11,10 @@ public class TextCombinatorTests
     {
         AssertParser.SucceedsWith(Character.AnyChar.Many().Text(), "ab", "ab");
     }
+
+    [Fact]
+    public void TextSucceedsWithTextSpanInput()
+    {
+        AssertParser.SucceedsWith(Span.Length(2).Text(), "ab", "ab");
+    }
 }

--- a/test/Superpower.Tests/Combinators/TextCombinatorTests.cs
+++ b/test/Superpower.Tests/Combinators/TextCombinatorTests.cs
@@ -1,0 +1,14 @@
+﻿using Superpower.Parsers;
+using Superpower.Tests.Support;
+using Xunit;
+
+namespace Superpower.Tests.Combinators;
+
+public class TextCombinatorTests
+{
+    [Fact]
+    public void TextSucceedsWithAnyCharArrayInput()
+    {
+        AssertParser.SucceedsWith(Character.AnyChar.Many().Text(), "ab", "ab");
+    }
+}


### PR DESCRIPTION
Solves #86

Hi,

I saw that #86 is marked 'up-for-grabs' while migrating dotnet-env from Sprache to superpower (https://github.com/tonerdo/dotnet-env/pull/106).
I additionally added the shorthand for TextSpans too, guess that would be helpful too.

Let me know if code/tests/comments are okay that way.