### PR TITLE
[Proposal] Adds TextSpan.AsReadOnlySpan() & numerics exponential parser

### DIFF
--- a/src/Superpower/Model/TextSpan.cs
+++ b/src/Superpower/Model/TextSpan.cs
@@ -234,6 +234,16 @@ namespace Superpower.Model
         }
 
         /// <summary>
+        /// Compute the string value of this span and return the view of source directly.
+        /// </summary>
+        /// <returns>A view of string with the value of this span.</returns>
+        public ReadOnlySpan<char> AsReadOnlySpan()
+        {
+            EnsureHasValue();
+            return Source!.AsSpan(Position.Absolute, Length);
+        }
+
+        /// <summary>
         /// Compare the contents of this span with <paramref name="otherValue"/>.
         /// </summary>
         /// <param name="otherValue">The string value to compare.</param>

--- a/src/Superpower/Parsers/Numerics.cs
+++ b/src/Superpower/Parsers/Numerics.cs
@@ -267,5 +267,53 @@ namespace Superpower.Parsers
             
             return Result.Value(val, input, remainder);
         };
+
+        /// <summary>
+        /// Matches exponential numbers.
+        /// </summary>
+        public static TextParser<TextSpan> Exponential { get; } = static input =>
+        {
+            var frac = Decimal(input);
+            if (!frac.HasValue)
+            {
+                return frac;
+            }
+            var separator = Character.EqualTo('e').Or(Character.EqualTo('E'))(frac.Remainder);
+            if (!separator.HasValue)
+            {
+                return Result.CastEmpty<char, TextSpan>(separator);
+            }
+            var exponent = Integer(separator.Remainder);
+            if (!exponent.HasValue)
+            {
+            }
+            return Result.Value(input.Until(exponent.Remainder), input, exponent.Remainder);
+        };
+
+        /// <summary>
+        /// A string of exponential numbers, converted into a<see cref="double"/>.
+        /// </summary>
+        public static TextParser<double> ExponentialDouble { get; } =
+            Exponential.Select(span => double.Parse(
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+                span.AsReadOnlySpan(),
+#else
+                span.ToStringValue(),
+#endif
+                NumberStyles.AllowExponent | NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint,
+                CultureInfo.InvariantCulture));
+
+        /// <summary>
+        /// A string of exponential numbers, converted into a<see cref="decimal"/>.
+        /// </summary>
+        public static TextParser<decimal> ExponentialDecimal { get; } =
+            Exponential.Select(span => decimal.Parse(
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP2_1_OR_GREATER
+                span.AsReadOnlySpan(),
+#else
+                span.ToStringValue(),
+#endif
+                NumberStyles.AllowExponent | NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint,
+                CultureInfo.InvariantCulture));
     }
 }

--- a/src/Superpower/Superpower.csproj
+++ b/src/Superpower/Superpower.csproj
@@ -25,7 +25,8 @@
   <ItemGroup>
     <None Include="..\..\asset\Superpower-White-400px.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
-  <ItemGroup>
+    
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
 </Project>

--- a/src/Superpower/Superpower.csproj
+++ b/src/Superpower/Superpower.csproj
@@ -25,4 +25,7 @@
   <ItemGroup>
     <None Include="..\..\asset\Superpower-White-400px.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.6.3" />
+  </ItemGroup>
 </Project>

--- a/test/Superpower.Tests/Parsers/NumericsTests.cs
+++ b/test/Superpower.Tests/Parsers/NumericsTests.cs
@@ -101,5 +101,44 @@ namespace Superpower.Tests.Parsers
             var parsed = Numerics.DecimalDouble.Parse("-123.456");
             Assert.Equal(-123.456, parsed);
         }
+
+        [Theory]
+        [InlineData("1", false)]
+        [InlineData("1e0", true)]
+        [InlineData("1E0", true)]
+        [InlineData("1e+0", true)]
+        [InlineData("1e-0", true)]
+        [InlineData("1E+0", true)]
+        [InlineData("1E-0", true)]
+        [InlineData("+1e+0", true)]
+        [InlineData("-1e-0", true)]
+        [InlineData("1.23e45", true)]
+        [InlineData("1.23e+45", true)]
+        [InlineData("1.23e-45", true)]
+        [InlineData("+1.23e+45", true)]
+        [InlineData("-1.23e-45", true)]
+        [InlineData("1+e1", false)]
+        [InlineData("1e+.1", false)]
+        [InlineData("e+1", false)]
+        public void ExponentialNumbersAreRecognized(string input, bool isMatch)
+        {
+            AssertParser.FitsTheory(Numerics.Exponential, input, isMatch);
+        }
+
+
+        [Fact]
+        public void ExponentialDecimalAreParsed()
+        {
+            var parsed = Numerics.ExponentialDecimal.Parse("-1.23e-45");
+            Assert.Equal(-1.23e-45m, parsed);
+        }
+
+        [Fact]
+        public void ExponentialDoubleAreParsed()
+        {
+            var parsed = Numerics.ExponentialDouble.Parse("-1.23e-45");
+            Assert.Equal(-1.23e-45, parsed);
+        }
+
     }
 }


### PR DESCRIPTION
Hello.

This pull request introduces 2 related features:

- `TextSpan.AsReadOnlySpan()`:
  provides the foundation for using modern span-based APIs, paving the way for improved performance.
- support for parsing exponential notation in numeric parsers:
  the changes enhance the existing numerics parsing capabilities to correctly handle numbers expressed in exponential (scientific) format, such as `1.23e4` or `-5.67E-8`.

### Key Changes

- Added parsing logic for exponential notation in the numeric parsers.
- Updated relevant tests to cover exponential number formats.
- Improved documentation and comments for clarity regarding exponential parsing.

### Motivation

Supporting exponential notation is essential for applications that process scientific or engineering data, where such formats are commonly used. This update ensures that the library can robustly handle a wider range of numeric inputs.

### Impact

- External package dependency: New reference to [System.Memory](https://www.nuget.org/packages/System.Memory) is introduced only for `'$(TargetFramework)'=='netstandard2.0'`.
- Backward compatible: Existing numeric parsing remains unaffected.
- No breaking changes to public APIs.

----

Please let me know if you need a more detailed or customized description.
Thank you.