### PR TITLE
[Proposal] Adds TextSpan.AsReadOnlySpan()

### DIFF
--- a/src/Superpower/Model/TextSpan.cs
+++ b/src/Superpower/Model/TextSpan.cs
@@ -234,6 +234,16 @@ namespace Superpower.Model
         }
 
         /// <summary>
+        /// Compute the string value of this span and return the view of source directly.
+        /// </summary>
+        /// <returns>A view of string with the value of this span.</returns>
+        public ReadOnlySpan<char> AsReadOnlySpan()
+        {
+            EnsureHasValue();
+            return Source!.AsSpan(Position.Absolute, Length);
+        }
+
+        /// <summary>
         /// Compare the contents of this span with <paramref name="otherValue"/>.
         /// </summary>
         /// <param name="otherValue">The string value to compare.</param>

--- a/src/Superpower/Superpower.csproj
+++ b/src/Superpower/Superpower.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <None Include="..\..\asset\Superpower-White-400px.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
 </Project>

--- a/src/Superpower/Superpower.csproj
+++ b/src/Superpower/Superpower.csproj
@@ -25,4 +25,7 @@
   <ItemGroup>
     <None Include="..\..\asset\Superpower-White-400px.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.6.3" />
+  </ItemGroup>
 </Project>

--- a/test/Superpower.Tests/Model/TextSpanTest.cs
+++ b/test/Superpower.Tests/Model/TextSpanTest.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Superpower.Model;
+using Xunit;
+
+namespace Superpower.Tests.Model
+{
+    public class TextSpanTest
+    {
+        [Theory]
+        [InlineData("hello", 0, 5, "hello")]
+        [InlineData("hello", 1, 3, "ell")]
+        [InlineData("hello", 2, 0, "")]
+        [InlineData("The quick brown fox jumps over the lazy dog", 9, 7, " brown ")]
+        public void AsReadOnlySpanWorks(string input, int start, int length, string expected)
+        {
+            var span = new TextSpan(input).Skip(start).First(length);
+            var readOnlySpan = span.AsReadOnlySpan();
+            Assert.Equal(expected, readOnlySpan.ToString());
+        }
+
+        [Fact]
+        public void AsReadOnlySpanEnsureHasValue()
+        {
+            Assert.Throws<InvalidOperationException>(() => TextSpan.None.AsReadOnlySpan());
+        }
+    }
+}


### PR DESCRIPTION
This proposal is a part of #168, with a new unit test code.

---- 

This pull request introduces a feature:

- `TextSpan.AsReadOnlySpan()`:
  provides the foundation for using modern span-based APIs, paving the way for improved performance.

## Impact 

- External package dependency: New reference to [System.Memory](https://www.nuget.org/packages/System.Memory) is introduced only for `'$(TargetFramework)'=='netstandard2.0'`.