### PR TITLE
Remove duplicate (incorrect, but overridden) signing key information from `Directory.Build.props`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,9 @@
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!-- The condition is required to support BenchmarkDotNet -->
-        <SignAssembly Condition="Exists('../../assets/SerilogTracing.snk')">true</SignAssembly>
-        <AssemblyOriginatorKeyFile>../../assets/SerilogTracing.snk</AssemblyOriginatorKeyFile>
+        <SignAssembly Condition="Exists('../../asset/Superpower.snk')">true</SignAssembly>
+        <AssemblyOriginatorKeyFile>../../asset/Superpower.snk</AssemblyOriginatorKeyFile>
+        <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <NoWarn>NETSDK1138</NoWarn>

--- a/src/Superpower/Superpower.csproj
+++ b/src/Superpower/Superpower.csproj
@@ -3,18 +3,10 @@
     <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <Description>A parser combinator library for C#</Description>
     <Authors>Datalust;Superpower Contributors;Sprache Contributors</Authors>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyOriginatorKeyFile>../../asset/Superpower.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageTags>superpower;parser</PackageTags>
     <PackageProjectUrl>https://github.com/datalust/superpower</PackageProjectUrl>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <PackageIcon>Superpower-White-400px.png</PackageIcon>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/datalust/superpower</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DefineConstants>$(DefineConstants);CHECKED</DefineConstants>


### PR DESCRIPTION
I grabbed the `Directory.Build.props` from our more recent _SerilogTracing_ build but missed updating the key name. The CSPROJ overrode these incorrect entries, so the net result was correct, but it's not something to leave hanging around :)