### PR TITLE
Build now runs on Linux, don't inadvertently delay-sign public packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,13 +4,12 @@
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <VersionPrefix>3.2.0</VersionPrefix>
+        <VersionPrefix>3.2.1</VersionPrefix>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!-- The condition is required to support BenchmarkDotNet -->
         <SignAssembly Condition="Exists('../../asset/Superpower.snk')">true</SignAssembly>
         <AssemblyOriginatorKeyFile>../../asset/Superpower.snk</AssemblyOriginatorKeyFile>
-        <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <NoWarn>NETSDK1138</NoWarn>


### PR DESCRIPTION
Release assemblies shouldn't use `<PublicSign>`; fixes #176.

We should seek verification on `dev` via the prerelease packages before merging this to `main`.